### PR TITLE
pkg-config is needed for thrift... this comes up on bare machines (do…

### DIFF
--- a/apache-thrift.lwr
+++ b/apache-thrift.lwr
@@ -37,6 +37,7 @@ depends:
 - libevent
 - python
 - ssl
+- pkg-config
 gitrev: 0.9.3
 inherit: bootstrapautoconf
 source: git+https://github.com/apache/thrift.git


### PR DESCRIPTION
…cker)