### PR TITLE
run boost commands from boost source-tree

### DIFF
--- a/boost.lwr
+++ b/boost.lwr
@@ -23,7 +23,7 @@ depends:
 - python
 - libbzip
 install: cd .. && ./bjam --threading=multi --layout=tagged link=shared -j$makewidth install --build-dir=build
-install_static: 'cd && ./bjam cxxflags=''-fPIC'' --threading=multi --layout=tagged link=static
+install_static: 'cd .. && ./bjam cxxflags=''-fPIC'' --threading=multi --layout=tagged link=static
   -j$makewidth install --build-dir=build
   '
 satisfy:

--- a/boost.lwr
+++ b/boost.lwr
@@ -18,13 +18,13 @@
 #
 
 category: baseline
-configure: ./bootstrap.sh --prefix=$prefix --libdir=$prefix/lib/
+configure: cd .. && ./bootstrap.sh --prefix=$prefix --libdir=$prefix/lib/
 depends:
 - python
 - libbzip
-install: ./bjam --threading=multi --layout=tagged link=shared -j$makewidth install
-install_static: './bjam cxxflags=''-fPIC'' --threading=multi --layout=tagged link=static
-  -j$makewidth install
+install: cd .. && ./bjam --threading=multi --layout=tagged link=shared -j$makewidth install --build-dir=build
+install_static: 'cd && ./bjam cxxflags=''-fPIC'' --threading=multi --layout=tagged link=static
+  -j$makewidth install --build-dir=build
   '
 satisfy:
   deb: (libboost1.53-dev && libboost-date-time1.53-dev && libboost-filesystem1.53-dev


### PR DESCRIPTION
Building boost from source requires running bootstrap and bjam from the source tree. There may be a better way to do this, but I found this to work. The build still takes place in build.

Related, is there a recipe variable that contains the full path to the build directory?