### PR TITLE
perform a full-depth clone of gnuradio

### DIFF
--- a/gnuradio.lwr
+++ b/gnuradio.lwr
@@ -45,7 +45,7 @@ satisfy:
   deb: gnuradio-dev
 source: git+https://github.com/gnuradio/gnuradio.git
 gitbranch: master
-gitargs: --recursive --depth=1
+gitargs: --recursive
 vars:
   config_opt: " -DENABLE_DOXYGEN=$builddocs "
 inherit: cmake


### PR DESCRIPTION
If the default behavior is going to be a binary package install, then environments that set a source build of gnuradio probably want the full repo.