### PR TITLE
Thrift

### DIFF
--- a/apache-thrift.lwr
+++ b/apache-thrift.lwr
@@ -38,6 +38,7 @@ depends:
 - python
 - ssl
 - pkg-config
+- twisted
 gitrev: 0.9.3
 inherit: bootstrapautoconf
 source: git+https://github.com/apache/thrift.git

--- a/twisted.lwr
+++ b/twisted.lwr
@@ -18,11 +18,8 @@
 #
 
 category: baseline
-depends:
-- python
-- setuptools
-inherit: setuptools
+depends: null
 satisfy:
-  deb: python-tornado >= 2.4
-  rpm: python-tornado >= 2.4
-source: wget+https://github.com/downloads/facebook/tornado/tornado-2.4.tar.gz
+  deb: python-twisted
+  rpm: python-twisted
+  cmd: trial


### PR DESCRIPTION
Twisted contains a tool called trial which thrift requires to properly configure python bindings. It's not clear if trial is ever used or if it's a proxy for testing if twisted exists and I didn't care to find out. I'm 99% sure it's a build-time only dependency since I can install python-thrift without it bringing in twisted.

This adds a new recipe to install all of twisted and depend on that for apache-thrift. Tested on Debian 8.3. trial comes with python-twisted-core (on Debian) which may be all that's actually needed.

@balister, you might find the above information useful for oe support