### PR TITLE
Fix pyqwt5 compilation

### DIFF
--- a/pyqwt5.lwr
+++ b/pyqwt5.lwr
@@ -33,14 +33,14 @@ configure: 'sed ''s/-lqwt/-lqwt-qt4/'' ../qwt-5.2/qwt.prf > ../qwt-5.2/qwt.prf.t
 
   cp qwt5qt4/Makefile.tmp qwt5qt4/Makefile
 
-  sed ''s/\/usr\/share\/sip\//$reprefix\/share\/sip\//'' qwt5qt4/Makefile > qwt5qt4/Makefile.tmp
+  sed ''s/\/usr\/share\/sip\//$prefix\/share\/sip\//'' qwt5qt4/Makefile > qwt5qt4/Makefile.tmp
   && \
 
   cp qwt5qt4/Makefile.tmp qwt5qt4/Makefile
 
   mkdir -p $prefix/share/sip/PyQt4/Qwt5
 
-  sed ''s/\/usr\/lib64\/python2.6\/site-packages\/PyQt4\//$reprefix\/lib\/python2.6\/site-packages\/PyQt4\//''
+  sed ''s/\/usr\/lib64\/python2.6\/site-packages\/PyQt4\//$prefix\/lib\/python2.6\/site-packages\/PyQt4\//''
   qwt5qt4/Makefile > qwt5qt4/Makefile.tmp && \
 
   cp qwt5qt4/Makefile.tmp qwt5qt4/Makefile


### PR DESCRIPTION
Compilation currently fails due to unresolved 'reprefix' variable. The
following incorrect sed command is executed during install with prefix
'/usr/local':

sed 's/\/usr\/share\/sip\//\/share\/sip\//' qwt5qt4/Makefile > qwt5qt4/Makefile.tmp

This command results in an incorrect Makefile and failed compilation.

This fix replaces 'reprefix' with 'prefix' so the following sed command
is executed:

sed 's/\/usr\/share\/sip\///usr/local\/share\/sip\//' qwt5qt4/Makefile > qwt5qt4/Makefile.tmp