### PR TITLE
Recipes added for networkx and pygraphviz, dependency on networkx for gnuradio

### DIFF
--- a/networkx.lwr
+++ b/networkx.lwr
@@ -1,0 +1,26 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+depends:
+- pygraphviz
+category: baseline
+satisfy:
+  deb: python-networkx
+  rpm: python-networkx
+  

--- a/pygraphviz.lwr
+++ b/pygraphviz.lwr
@@ -1,0 +1,25 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+depends: null
+category: baseline
+satisfy:
+  deb: python-pygraphviz
+  rpm: python-pygraphviz
+  


### PR DESCRIPTION
gr-perf-monitorx calls networkx and pygraphviz. pygraphviz should be a package-level
dependency for networkx, but for some reason isn't.

Tested with a maint build for gnuradio and uhd.