### PR TITLE
Corrupt URL in qt4 recipe

### DIFF
--- a/qt4.lwr
+++ b/qt4.lwr
@@ -22,6 +22,6 @@ inherit: autoconf
 satisfy:
   deb: libqt4-dev >= 4.6.2
   rpm: qt-devel >= 4.6.2 || qt4-devel >= 4.6.2
-source: wget+ftp://ftp.qt.nokia.com/qt/source/qt-everywhere-opensource-src-4.6.2.tar.gz
+source: wget+https://download.qt.io/archive/qt/4.6/qt-everywhere-opensource-src-4.6.2.tar.gz
 vars:
   config_opt: -opensource --confirm-license -L$prefix/lib -L$prefix/lib64


### PR DESCRIPTION
The former URL is no longer reachable. I replaced it with a valid one.