### PR TITLE
Removed all the `wget+`, following discussion of gnuradio/pybombs#290

### DIFF
--- a/alsa.lwr
+++ b/alsa.lwr
@@ -22,4 +22,4 @@ inherit: autoconf
 satisfy:
   deb: libasound2-dev
   rpm: alsa-lib-devel
-source: wget+http://www.tux.org/pub/sites/ftp.alsa-project.org/lib/alsa-lib-1.0.27.2.tar.bz2
+source: http://www.tux.org/pub/sites/ftp.alsa-project.org/lib/alsa-lib-1.0.27.2.tar.bz2

--- a/armadillo.lwr
+++ b/armadillo.lwr
@@ -26,6 +26,6 @@ inherit: cmake
 satisfy:
   deb: libarmadillo-dev
   rpm: armadillo-devel
-source: wget+http://sourceforge.net/projects/arma/files/armadillo-4.400.1.tar.gz
+source: http://sourceforge.net/projects/arma/files/armadillo-4.400.1.tar.gz
 vars:
   config_opt: ' -DINSTALL_LIB_DIR=$prefix/lib '

--- a/atk.lwr
+++ b/atk.lwr
@@ -22,4 +22,4 @@ inherit: autoconf
 satisfy:
   deb: libatk1.0-0 >= 1.29.2
   rpm: atk-devel >= 1.29.2
-source: wget+http://ftp.gnome.org/pub/gnome/sources/atk/1.30/atk-1.30.0.tar.bz2
+source: http://ftp.gnome.org/pub/gnome/sources/atk/1.30/atk-1.30.0.tar.bz2

--- a/autoconf.lwr
+++ b/autoconf.lwr
@@ -22,4 +22,4 @@ inherit: autoconf
 satisfy:
   deb: autoconf >= 2.69
   rpm: autoconf >= 2.69
-source: wget+http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
+source: http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz

--- a/automake.lwr
+++ b/automake.lwr
@@ -22,4 +22,4 @@ inherit: autoconf
 satisfy:
   deb: automake >= 1.14
   rpm: automake >= 1.14
-source: wget+http://ftp.gnu.org/gnu/automake/automake-1.15.tar.gz
+source: http://ftp.gnu.org/gnu/automake/automake-1.15.tar.gz

--- a/bison.lwr
+++ b/bison.lwr
@@ -23,4 +23,4 @@ satisfy:
   deb: bison >= 2.3
   rpm: bison >= 2.3
   cmd: bison --version >= 2.3
-source: wget+http://ftp.gnu.org/gnu/bison/bison-2.3.tar.gz
+source: http://ftp.gnu.org/gnu/bison/bison-2.3.tar.gz

--- a/boost.lwr
+++ b/boost.lwr
@@ -34,4 +34,4 @@ satisfy:
     >= 1.53) && (libboost-regex-dev >= 1.53) && (libboost-thread-dev >= 1.53) && (libboost-test-dev
     >=1.53))
   rpm: boost-devel >= 1.53
-source: wget+http://downloads.sourceforge.net/project/boost/boost/1.53.0/boost_1_53_0.tar.bz2
+source: http://downloads.sourceforge.net/project/boost/boost/1.53.0/boost_1_53_0.tar.bz2

--- a/cairo.lwr
+++ b/cairo.lwr
@@ -27,4 +27,4 @@ inherit: autoconf
 satisfy:
   deb: libcairo2 >= 1.8.10
   rpm: cairo-devel >= 1.8.10
-source: wget+http://cairographics.org/releases/cairo-1.8.10.tar.gz
+source: http://cairographics.org/releases/cairo-1.8.10.tar.gz

--- a/cheetah.lwr
+++ b/cheetah.lwr
@@ -24,4 +24,4 @@ inherit: distutils
 satisfy:
   deb: python-cheetah >= 2.0
   rpm: python-cheetah >= 2.0
-source: wget+http://prdownloads.sourceforge.net/cheetahtemplate/Cheetah-2.0.1.tar.gz
+source: http://prdownloads.sourceforge.net/cheetahtemplate/Cheetah-2.0.1.tar.gz

--- a/cmake.lwr
+++ b/cmake.lwr
@@ -25,4 +25,4 @@ inherit: autoconf
 satisfy:
   deb: (cmake >= 2.8.3) && (cmake-data >= 2.8.3)
   rpm: (cmake >= 2.8.3)
-source: wget+http://www.cmake.org/files/v2.8/cmake-2.8.6.tar.gz
+source: http://www.cmake.org/files/v2.8/cmake-2.8.6.tar.gz

--- a/cppunit.lwr
+++ b/cppunit.lwr
@@ -22,6 +22,6 @@ inherit: autoconf
 satisfy:
   deb: libcppunit-dev
   rpm: cppunit-devel
-source: wget+http://prdownloads.sourceforge.net/cppunit/cppunit-1.12.1.tar.gz
+source: http://prdownloads.sourceforge.net/cppunit/cppunit-1.12.1.tar.gz
 vars:
   config_opt: LIBS=-ldl

--- a/e300.lwr
+++ b/e300.lwr
@@ -3,7 +3,7 @@ config:
   builddocs: false
   setup_env: $PYBOMBS_PREFIX/environment-setup-armv7ahf-vfp-neon-oe-linux-gnueabi
 installdir: .
-source: wget+http://files.ettus.com/e4xx_images/e3xx-release-4/oecore-x86_64-armv7ahf-vfp-neon-toolchain-nodistro.0.sh
+source: http://files.ettus.com/e4xx_images/e3xx-release-4/oecore-x86_64-armv7ahf-vfp-neon-toolchain-nodistro.0.sh
 #source: file+/path/to/oecore-x86_64-armv7ahf-vfp-neon-toolchain-nodistro.0.sh
 install: sh ./oecore-x86_64-armv7ahf-vfp-neon-toolchain-nodistro.0.sh -y -d $prefix
 clean: [oecore-x86_64-armv7ahf-vfp-neon-toolchain-nodistro.0.sh, ]

--- a/expat.lwr
+++ b/expat.lwr
@@ -22,6 +22,6 @@ inherit: autoconf
 satisfy:
   deb: libexpat1-dev >= 2.0.1
   rpm: expat-devel >= 2.0.1
-source: wget+http://downloads.sourceforge.net/project/expat/expat/2.0.1/expat-2.0.1.tar.gz
+source: http://downloads.sourceforge.net/project/expat/expat/2.0.1/expat-2.0.1.tar.gz
 vars:
   config_opt: ' --libdir=$prefix/lib64 '

--- a/ffi.lwr
+++ b/ffi.lwr
@@ -25,4 +25,4 @@ inherit: autoconf
 satisfy:
   deb: libffi6
   rpm: libffi-devel
-source: wget+https://www.mirrorservice.org/sites/sourceware.org/pub/libffi/libffi-3.0.9.tar.gz
+source: https://www.mirrorservice.org/sites/sourceware.org/pub/libffi/libffi-3.0.9.tar.gz

--- a/fftw.lwr
+++ b/fftw.lwr
@@ -22,6 +22,6 @@ inherit: autoconf
 satisfy:
   deb: libfftw3-3 && libfftw3-dev
   rpm: fftw-devel
-source: wget+http://www.fftw.org/fftw-3.3.2.tar.gz
+source: http://www.fftw.org/fftw-3.3.2.tar.gz
 vars:
   config_opt: --enable-single --enable-shared

--- a/flex.lwr
+++ b/flex.lwr
@@ -23,4 +23,4 @@ satisfy:
   deb: flex >= 2.5.35
   rpm: flex >= 2.5.35
   cmd: flex --version >= 2.5.35
-source: wget+http://prdownloads.sourceforge.net/flex/flex-2.5.35.tar.bz2
+source: http://prdownloads.sourceforge.net/flex/flex-2.5.35.tar.bz2

--- a/fontconfig.lwr
+++ b/fontconfig.lwr
@@ -24,4 +24,4 @@ inherit: autoconf
 satisfy:
   deb: libfontconfig1-dev >= 2.4.2
   rpm: fontconfig-devel >= 2.4.2
-source: wget+http://fontconfig.org/release/fontconfig-2.9.0.tar.gz
+source: http://fontconfig.org/release/fontconfig-2.9.0.tar.gz

--- a/freetype.lwr
+++ b/freetype.lwr
@@ -22,4 +22,4 @@ inherit: autoconf
 satisfy:
   deb: libfreetype6-dev
   rpm: freetype-devel
-source: wget+download.savannah.gnu.org/releases/freetype/freetype-2.4.0.tar.bz2
+source: download.savannah.gnu.org/releases/freetype/freetype-2.4.0.tar.bz2

--- a/gdk-pixbuf.lwr
+++ b/gdk-pixbuf.lwr
@@ -28,4 +28,4 @@ inherit: autoconf
 satisfy:
   deb: libgdk-pixbuf2.0-dev >= 2.21.0
   rpm: (gdk-pixbuf-devel >= 2.21.0) || (gdk-pixbuf2-devel >= 2.21.0)
-source: wget+http://ftp.gnome.org/pub/gnome/sources/gdk-pixbuf/2.24/gdk-pixbuf-2.24.0.tar.bz2
+source: http://ftp.gnome.org/pub/gnome/sources/gdk-pixbuf/2.24/gdk-pixbuf-2.24.0.tar.bz2

--- a/gflags.lwr
+++ b/gflags.lwr
@@ -21,4 +21,4 @@ category: baseline
 inherit: autoconf
 satisfy:
   deb: libgflags-dev
-source: wget+https://gflags.googlecode.com/files/gflags-2.0.tar.gz
+source: https://gflags.googlecode.com/files/gflags-2.0.tar.gz

--- a/gfortran.lwr
+++ b/gfortran.lwr
@@ -28,7 +28,7 @@ satisfy:
   deb: gfortran >= 4.5.2
   rpm: gcc-gfortran >= 4.5.2
   cmd: gfortran --version >= 4.5.2
-source: wget+http://www.netgull.com/gcc/releases/gcc-4.5.2/gcc-4.5.2.tar.bz2
+source: http://www.netgull.com/gcc/releases/gcc-4.5.2/gcc-4.5.2.tar.bz2
 vars:
   config_opt: ' --with-gmp=$prefix --with-mpfr=$prefix --disable-multilib --with-mpc=$prefix
     --enable-languages=fortran --disable-checking --disable-bootstrap --enable-threads

--- a/glib.lwr
+++ b/glib.lwr
@@ -22,4 +22,4 @@ inherit: autoconf
 satisfy:
   deb: libglib2.0-dev >= 2.27.2
   rpm: glib2-devel >= 2.27.2
-source: wget+http://ftp.gnome.org/pub/gnome/sources/glib/2.27/glib-2.27.2.tar.bz2
+source: http://ftp.gnome.org/pub/gnome/sources/glib/2.27/glib-2.27.2.tar.bz2

--- a/glog.lwr
+++ b/glog.lwr
@@ -21,4 +21,4 @@ category: baseline
 inherit: autoconf
 satisfy:
   deb: libgoogle-glog-dev
-source: wget+http://google-glog.googlecode.com/files/glog-0.3.3.tar.gz
+source: http://google-glog.googlecode.com/files/glog-0.3.3.tar.gz

--- a/gmp.lwr
+++ b/gmp.lwr
@@ -21,4 +21,4 @@ category: baseline
 inherit: autoconf
 satisfy:
   deb: libgmp-dev
-source: wget+http://archive.ubuntu.com/ubuntu/pool/main/g/gmp/gmp_4.3.2+dfsg.orig.tar.gz
+source: http://archive.ubuntu.com/ubuntu/pool/main/g/gmp/gmp_4.3.2+dfsg.orig.tar.gz

--- a/gobject-introspection.lwr
+++ b/gobject-introspection.lwr
@@ -30,4 +30,4 @@ inherit: autoconf
 satisfy:
   deb: gobject-introspection >= 0.10.2
   rpm: gobject-introspection >= 0.9.3
-source: wget+http://ftp.gnome.org/pub/GNOME/sources/gobject-introspection/0.10/gobject-introspection-0.10.2.tar.bz2
+source: http://ftp.gnome.org/pub/GNOME/sources/gobject-introspection/0.10/gobject-introspection-0.10.2.tar.bz2

--- a/gperftools.lwr
+++ b/gperftools.lwr
@@ -21,6 +21,6 @@ category: baseline
 inherit: autoconf
 satisfy:
   deb: google-perftools
-source: wget+http://gperftools.googlecode.com/files/gperftools-2.0.tar.gz
+source: http://gperftools.googlecode.com/files/gperftools-2.0.tar.gz
 vars:
   config_opt: ' --enable-frame-pointers '

--- a/gsl.lwr
+++ b/gsl.lwr
@@ -22,4 +22,4 @@ inherit: autoconf
 satisfy:
   deb: (libgsl0-dev >= 1.13) && (libgsl0ldbl >= 1.13)
   rpm: gsl-devel >= 1.13
-source: wget+http://mirror.nexcess.net/gnu/gsl/gsl-1.13.tar.gz
+source: http://mirror.nexcess.net/gnu/gsl/gsl-1.13.tar.gz

--- a/gtk2.lwr
+++ b/gtk2.lwr
@@ -30,6 +30,6 @@ inherit: autoconf
 satisfy:
   deb: libgtk2.0-dev >= 2.21.8
   rpm: gtk2-devel >= 2.21.8
-source: wget+http://ftp.gnome.org/pub/gnome/sources/gtk+/2.21/gtk+-2.21.8.tar.bz2
+source: http://ftp.gnome.org/pub/gnome/sources/gtk+/2.21/gtk+-2.21.8.tar.bz2
 vars:
   config_opt: ' GDK_PIXBUF_CSOURCE=$prefix/bin/gdk-pixbuf-csource-2.0 '

--- a/lapack.lwr
+++ b/lapack.lwr
@@ -27,6 +27,6 @@ inherit: cmake
 satisfy:
   deb: liblapack-dev >= 3.3.0
   rpm: lapack-devel >= 3.3.0 || lapack >= 3.3.0
-source: wget+http://www.netlib.org/lapack/lapack-3.3.0.tgz
+source: http://www.netlib.org/lapack/lapack-3.3.0.tgz
 vars:
   config_opt: ' -DCMAKE_Fortran_COMPILER=$prefix/bin/fortran-gfortran -DBUILD_SHARED_LIBS=ON '

--- a/libbzip.lwr
+++ b/libbzip.lwr
@@ -18,7 +18,7 @@
 #
 
 category: baseline
-source: wget+https://launchpad.net/ubuntu/+archive/primary/+files/bzip2_1.0.6.orig.tar.bz2
+source: https://launchpad.net/ubuntu/+archive/primary/+files/bzip2_1.0.6.orig.tar.bz2
 satisfy:
   deb: libbz2-dev
   rpm: bzip2-devel

--- a/libitpp.lwr
+++ b/libitpp.lwr
@@ -22,4 +22,4 @@ inherit: autoconf
 satisfy:
   deb: libitpp-dev
   rpm: itpp-devel
-source: wget+http://downloads.sourceforge.net/project/itpp/itpp/4.3.1/itpp-4.3.1.tar.bz2
+source: http://downloads.sourceforge.net/project/itpp/itpp/4.3.1/itpp-4.3.1.tar.bz2

--- a/liblog4cpp.lwr
+++ b/liblog4cpp.lwr
@@ -27,6 +27,6 @@ inherit: autoconf
 satisfy:
   deb: liblog4cpp5-dev
   rpm: log4cpp-devel && log4cpp
-source: wget+http://prdownloads.sourceforge.net/log4cpp/log4cpp-1.1.1.tar.gz
+source: http://prdownloads.sourceforge.net/log4cpp/log4cpp-1.1.1.tar.gz
 vars:
   config_opt: --with-pthreads

--- a/libpcap.lwr
+++ b/libpcap.lwr
@@ -22,4 +22,4 @@ inherit: autoconf
 satisfy:
   deb: libpcap-dev
   rpm: libpcap-devel
-source: wget+http://www.tcpdump.org/release/libpcap-1.3.0.tar.gz
+source: http://www.tcpdump.org/release/libpcap-1.3.0.tar.gz

--- a/libpng.lwr
+++ b/libpng.lwr
@@ -22,4 +22,4 @@ inherit: autoconf
 satisfy:
   deb: libpng12-dev >= 1.2.41
   rpm: libpng-devel >= 1.2.41
-source: wget+https://launchpad.net/ubuntu/+archive/primary/+files/libpng_1.2.42.orig.tar.bz2
+source: https://launchpad.net/ubuntu/+archive/primary/+files/libpng_1.2.42.orig.tar.bz2

--- a/libpolarssl.lwr
+++ b/libpolarssl.lwr
@@ -21,4 +21,4 @@ category: baseline
 inherit: cmake
 satisfy:
   deb: libpolarssl-dev
-source: wget+https://polarssl.org/download/polarssl-1.3.8-gpl.tgz
+source: https://polarssl.org/download/polarssl-1.3.8-gpl.tgz

--- a/libsndfile.lwr
+++ b/libsndfile.lwr
@@ -22,4 +22,4 @@ inherit: autoconf
 satisfy:
   deb: libsndfile-dev || libsndfile1-dev
   rpm: libsndfile-devel
-source: wget+http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.25.tar.gz
+source: http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.25.tar.gz

--- a/libusb.lwr
+++ b/libusb.lwr
@@ -23,4 +23,4 @@ satisfy:
   deb: libusb-1.0-0-dev >= 1.0.9
   rpm: (libusb-devel >= 1.0.9) || (libusbx-devel >= 1.0.9)
   pkgconfig: libusb-1.0
-source: wget+http://sourceforge.net/projects/libusb/files/libusb-1.0/libusb-1.0.9/libusb-1.0.9.tar.bz2
+source: http://sourceforge.net/projects/libusb/files/libusb-1.0/libusb-1.0.9/libusb-1.0.9.tar.bz2

--- a/libxml.lwr
+++ b/libxml.lwr
@@ -22,4 +22,4 @@ inherit: autoconf
 satisfy:
   deb: libxml2-dev >= 2.7
   rpm: libxml2-devel >= 2.7
-source: wget+http://xmlsoft.org/sources/libxml2-2.7.2.tar.gz
+source: http://xmlsoft.org/sources/libxml2-2.7.2.tar.gz

--- a/libxslt.lwr
+++ b/libxslt.lwr
@@ -22,4 +22,4 @@ inherit: autoconf
 satisfy:
   deb: libxslt1-dev >= 1.1
   rpm: libxslt-devel >= 1.1
-source: wget+http://xmlsoft.org/sources/libxslt-1.1.20.tar.gz
+source: http://xmlsoft.org/sources/libxslt-1.1.20.tar.gz

--- a/lxml.lwr
+++ b/lxml.lwr
@@ -27,4 +27,4 @@ inherit: distutils
 satisfy:
   deb: python-lxml >= 2.3.2
   rpm: python-lxml >= 2.3.2
-source: wget+http://lxml.de/files/lxml-2.3.3.tgz
+source: http://lxml.de/files/lxml-2.3.3.tgz

--- a/make.lwr
+++ b/make.lwr
@@ -26,5 +26,5 @@ satisfy:
   deb: (make >= 3.75)
   rpm: (make >= 3.75)
   cmd: make --version >= 3.75
-source: wget+http://ftp.gnu.org/gnu/make/make-3.82.tar.gz
+source: http://ftp.gnu.org/gnu/make/make-3.82.tar.gz
 uninstall: ./make uninstall

--- a/mcpp.lwr
+++ b/mcpp.lwr
@@ -33,6 +33,6 @@ satisfy:
   rpm: mcpp-devel >= 2.7.2
 source:
 - file+dist/mcpp_2.7.2.orig.tar.gz
-- wget+http://aptproxy.willowgarage.com/archive.ubuntu.com/ubuntu/pool/universe/m/mcpp/mcpp_2.7.2.orig.tar.gz
+- http://aptproxy.willowgarage.com/archive.ubuntu.com/ubuntu/pool/universe/m/mcpp/mcpp_2.7.2.orig.tar.gz
 vars:
   config_opt: ' --enable-mcpplib '

--- a/mpc.lwr
+++ b/mpc.lwr
@@ -24,6 +24,6 @@ depends:
 inherit: autoconf
 satisfy:
   deb: libmpc-dev >= 0.9
-source: wget+http://www.multiprecision.org/mpc/download/mpc-0.9.tar.gz
+source: http://www.multiprecision.org/mpc/download/mpc-0.9.tar.gz
 vars:
   config_opt: ' --with-gmp=$prefix '

--- a/mpfr.lwr
+++ b/mpfr.lwr
@@ -24,6 +24,6 @@ inherit: autoconf
 satisfy:
   deb: libmpfr-dev >= 3.0.0
   rpm: mpfr-devel >= 3.0.0
-source: wget+http://www.mpfr.org/mpfr-3.0.0/mpfr-3.0.0.tar.gz
+source: http://www.mpfr.org/mpfr-3.0.0/mpfr-3.0.0.tar.gz
 vars:
   config_opt: ' --with-gmp-include=$prefix/include/ --with-gmp-lib=$prefix/lib/ '

--- a/niusrprio.lwr
+++ b/niusrprio.lwr
@@ -21,7 +21,7 @@ category: hardware
 make: 'sudo ./INSTALL'
 make_interactive: True
 installdir: ./
-source: wget+http://files.ettus.com/binaries/niusrprio/niusrprio-installer.tar.gz
+source: http://files.ettus.com/binaries/niusrprio/niusrprio-installer.tar.gz
 satisfy:
   cmd: niusrprio_pcie status
 

--- a/numpy.lwr
+++ b/numpy.lwr
@@ -26,4 +26,4 @@ inherit: distutils
 satisfy:
   deb: python-numpy >= 1.5
   rpm: numpy >= 1.5
-source: wget+http://prdownloads.sourceforge.net/numpy/numpy-1.6.2.tar.gz
+source: http://prdownloads.sourceforge.net/numpy/numpy-1.6.2.tar.gz

--- a/pango.lwr
+++ b/pango.lwr
@@ -24,4 +24,4 @@ inherit: autoconf
 satisfy:
   deb: libpango1.0-0 >= 1.28
   rpm: pango-devel >= 1.28
-source: wget+http://ftp.gnome.org/pub/gnome/sources/pango/1.28/pango-1.28.4.tar.bz2
+source: http://ftp.gnome.org/pub/gnome/sources/pango/1.28/pango-1.28.4.tar.bz2

--- a/pixman.lwr
+++ b/pixman.lwr
@@ -22,4 +22,4 @@ inherit: autoconf
 satisfy:
   deb: (libpixman-1-0 >= 0.18.4) || (libpixman-1-dev >= 0.18.4)
   rpm: pixman-devel >= 0.18.4
-source: wget+https://launchpad.net/ubuntu/+archive/primary/+files/pixman_0.18.4.orig.tar.gz
+source: https://launchpad.net/ubuntu/+archive/primary/+files/pixman_0.18.4.orig.tar.gz

--- a/protobuf.lwr
+++ b/protobuf.lwr
@@ -22,4 +22,4 @@ inherit: autoconf
 satisfy:
   deb: libprotobuf-dev >= 2.6.1
   rpm: protobuf-devel >= 2.6.1
-source: wget+https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz
+source: https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz

--- a/pycairo.lwr
+++ b/pycairo.lwr
@@ -34,4 +34,4 @@ make: './waf build
 satisfy:
   deb: python-cairo-dev >= 1.8
   rpm: pycairo-devel >= 1.8
-source: wget+http://cairographics.org/releases/py2cairo-1.8.10.tar.gz
+source: http://cairographics.org/releases/py2cairo-1.8.10.tar.gz

--- a/pygobject.lwr
+++ b/pygobject.lwr
@@ -28,6 +28,6 @@ install_like: gobject-introspection
 satisfy:
   deb: python-gobject-dev >= 2.27
   rpm: pygobject2-devel >= 2.27
-source: wget+http://ftp.gnome.org/pub/GNOME/sources/pygobject/2.27/pygobject-2.27.91.tar.gz
+source: http://ftp.gnome.org/pub/GNOME/sources/pygobject/2.27/pygobject-2.27.91.tar.gz
 vars:
   config_opt: ' --enable-introspection '

--- a/pygtk.lwr
+++ b/pygtk.lwr
@@ -30,4 +30,4 @@ install_like: gtk2
 satisfy:
   deb: python-gtk2 >= 2.17
   rpm: pygtk2-devel >= 2.17
-source: wget+http://ftp.gnome.org/pub/GNOME/sources/pygtk/2.17/pygtk-2.17.0.tar.bz2
+source: http://ftp.gnome.org/pub/GNOME/sources/pygtk/2.17/pygtk-2.17.0.tar.bz2

--- a/pyqt4.lwr
+++ b/pyqt4.lwr
@@ -28,4 +28,4 @@ install_like: qt4
 satisfy:
   deb: ( python-qt4 >= 4.6.2 ) && ( pyqt4-dev-tools >= 4.6.2 )
   rpm: PyQt4-devel >= 4.6.2
-source: wget+http://pkgs.fedoraproject.org/repo/pkgs/PyQt4/PyQt-x11-gpl-4.7.2.tar.gz/e7782e9146ec8aa0e76bcdb0ca5b9491/PyQt-x11-gpl-4.7.2.tar.gz
+source: http://pkgs.fedoraproject.org/repo/pkgs/PyQt4/PyQt-x11-gpl-4.7.2.tar.gz/e7782e9146ec8aa0e76bcdb0ca5b9491/PyQt-x11-gpl-4.7.2.tar.gz

--- a/pyqwt5.lwr
+++ b/pyqwt5.lwr
@@ -60,4 +60,4 @@ makedir: configure/
 satisfy:
   deb: python-qwt5-qt4 >= 5.2
   rpm: PyQwt-devel >= 5.2
-source: wget+http://prdownloads.sourceforge.net/pyqwt/PyQwt-5.2.0.tar.gz
+source: http://prdownloads.sourceforge.net/pyqwt/PyQwt-5.2.0.tar.gz

--- a/pysstv.lwr
+++ b/pysstv.lwr
@@ -24,4 +24,4 @@ depends:
 - libjpeg
 description: SSTV generator in pure Python
 inherit: distutils
-source: wget+https://pypi.python.org/packages/source/P/PySSTV/PySSTV-0.1.9.tar.gz
+source: https://pypi.python.org/packages/source/P/PySSTV/PySSTV-0.1.9.tar.gz

--- a/qt4.lwr
+++ b/qt4.lwr
@@ -22,6 +22,6 @@ inherit: autoconf
 satisfy:
   deb: libqt4-dev >= 4.6.2
   rpm: qt-devel >= 4.6.2 || qt4-devel >= 4.6.2
-source: wget+https://download.qt.io/archive/qt/4.6/qt-everywhere-opensource-src-4.6.2.tar.gz
+source: https://download.qt.io/archive/qt/4.6/qt-everywhere-opensource-src-4.6.2.tar.gz
 vars:
   config_opt: -opensource --confirm-license -L$prefix/lib -L$prefix/lib64

--- a/qwt5.lwr
+++ b/qwt5.lwr
@@ -28,4 +28,4 @@ make: "make    \n"
 satisfy:
   deb: libqwt5-qt4 && libqwt-dev
   rpm: qwt-devel >= 5.2
-source: wget+http://prdownloads.sourceforge.net/qwt/qwt-5.2.0.tar.bz2
+source: http://prdownloads.sourceforge.net/qwt/qwt-5.2.0.tar.bz2

--- a/scipy.lwr
+++ b/scipy.lwr
@@ -26,4 +26,4 @@ inherit: distutils
 satisfy:
   deb: python-scipy >= 0.8
   rpm: scipy
-source: wget+http://downloads.sourceforge.net/project/scipy/scipy/0.8.0/scipy-0.8.0.tar.gz
+source: http://downloads.sourceforge.net/project/scipy/scipy/0.8.0/scipy-0.8.0.tar.gz

--- a/setuptools.lwr
+++ b/setuptools.lwr
@@ -23,4 +23,4 @@ depends:
 satisfy:
   deb: python-setuptools >= 0.6
   rpm: python-setuptools >= 0.6
-source: wget+https://pypi.python.org/packages/source/s/setuptools/setuptools-0.6c11.tar.gz
+source: https://pypi.python.org/packages/source/s/setuptools/setuptools-0.6c11.tar.gz

--- a/sip.lwr
+++ b/sip.lwr
@@ -29,4 +29,4 @@ install_like: python
 satisfy:
   deb: python-sip-dev >= 4.10.1
   rpm: sip-devel >= 4.10.1
-source: wget+http://pkgs.fedoraproject.org/repo/pkgs/sip/sip-4.10.1.tar.gz/9fa0b0d17ad355bde004317f67c819f9/sip-4.10.1.tar.gz
+source: http://pkgs.fedoraproject.org/repo/pkgs/sip/sip-4.10.1.tar.gz/9fa0b0d17ad355bde004317f67c819f9/sip-4.10.1.tar.gz

--- a/swig.lwr
+++ b/swig.lwr
@@ -25,6 +25,6 @@ inherit: autoconf
 satisfy:
   deb: swig2.0
   rpm: swig >= 2.0
-source: wget+http://prdownloads.sourceforge.net/swig/swig-2.0.4.tar.gz
+source: http://prdownloads.sourceforge.net/swig/swig-2.0.4.tar.gz
 vars:
   config_opt: --without-pcre

--- a/wireshark.lwr
+++ b/wireshark.lwr
@@ -28,4 +28,4 @@ inherit: autoconf
 satisfy:
   deb: wireshark
   cmd: wireshark --version >= 1.0
-source: wget+http://wiresharkdownloads.riverbed.com/wireshark/src/all-versions/wireshark-1.10.2.tar.bz2
+source: http://wiresharkdownloads.riverbed.com/wireshark/src/all-versions/wireshark-1.10.2.tar.bz2

--- a/wxpython.lwr
+++ b/wxpython.lwr
@@ -42,6 +42,6 @@ make: 'make && \
 satisfy:
   deb: python-wxgtk2.8 || python-wxgtk3.0
   rpm: wxPython
-source: wget+http://prdownloads.sourceforge.net/wxpython/wxPython-src-2.8.11.0.tar.bz2
+source: http://prdownloads.sourceforge.net/wxpython/wxPython-src-2.8.11.0.tar.bz2
 vars:
   config_opt: ' --disable-unicode '

--- a/zeromq.lwr
+++ b/zeromq.lwr
@@ -24,4 +24,4 @@ inherit: autoconf
 satisfy:
   deb: libzmq3-dev
   rpm: cppzmq-devel
-source: wget+http://download.zeromq.org/zeromq-3.2.4.tar.gz
+source: http://download.zeromq.org/zeromq-3.2.4.tar.gz


### PR DESCRIPTION
https://github.com/gnuradio/pybombs/issues/290 concluded that it'd be nice to replace `wget+http` sources simply by `http` sources, which works, because it matches the regex https://github.com/gnuradio/pybombs/blob/master/pybombs/fetchers/wget.py defines.