### PR TITLE
pybombs pip definition doesn't check versions :(

### DIFF
--- a/mako.lwr
+++ b/mako.lwr
@@ -24,5 +24,5 @@ inherit: distutils
 satisfy:
   deb: python-mako >= 0.4.2
   rpm: python-mako >= 0.4.2
-  pip: Mako >= 0.4.2
+  pip: Mako
   pacman: python2-mako >= 0.4.2


### PR DESCRIPTION
In packagers/pip.py, the pip packager does not have the ability (AFAIK) to get a version number... it returns only True or False depending on whether there's a version at all... I guess this is the right thing since the pip package should be up to date.

This was causing a TypeError in utils/vcompare.py.