### PR TITLE
adding gr-mapper back into recipes

### DIFF
--- a/gr-mapper.lwr
+++ b/gr-mapper.lwr
@@ -1,0 +1,25 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends: gnuradio
+description: Symbol to Bit Mapping and Demapping Blocks for GNU Radio
+gitbranch: master
+inherit: cmake
+source: git+https://github.com/gr-vt/gr-mapper.git


### PR DESCRIPTION
gr-burst (which is in gr-recipes) depends on gr-mapper