### PR TITLE
CentOS 7

### DIFF
--- a/automake.lwr
+++ b/automake.lwr
@@ -17,6 +17,8 @@
 # Boston, MA 02110-1301, USA.
 #
 
+depends:
+- autoconf
 category: baseline
 inherit: empty
 configure: ./configure --prefix=$prefix $config_opt CC=$cc CXX=$cxx

--- a/libtool.lwr
+++ b/libtool.lwr
@@ -18,7 +18,13 @@
 #
 
 category: baseline
+depends:
+- wget
+- autoconf
+- automake
+inherit: autoconf
 satisfy:
-  deb: libtool
-  rpm: libtool
-  pacman: libtool
+  deb: libtool >= 2.4.6
+  rpm: libtool >= 2.4.6
+  pacman: libtool >= 2.4.6
+source: wget+http://ftpmirror.gnu.org/libtool/libtool-2.4.6.tar.gz

--- a/pkg-config.lwr
+++ b/pkg-config.lwr
@@ -17,8 +17,13 @@
 # Boston, MA 02110-1301, USA.
 #
 
+depends:
+- wget
+- libtool
 category: baseline
+inherit: autoconf
 satisfy:
-  deb: pkg-config
-  rpm: pkgconfig
-  pacman: pkg-config
+  deb: (pkg-config >= 0.28)
+  rpm: (pkg-config >= 0.28)
+  pacman: (pkg-config >= 0.28)
+source: wget+https://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz


### PR DESCRIPTION
Changes for installing GNU Radio on CentOS 7.  

For building Thrift, used minimum versions cited in [1] for dependencies.  Thrift build also works for CentOS 6.

[1] https://thrift.apache.org/docs/install/centos