### PR TITLE
Fixed bison version requirement

### DIFF
--- a/bison.lwr
+++ b/bison.lwr
@@ -20,8 +20,8 @@
 category: baseline
 inherit: autoconf
 satisfy:
-  deb: bison >= 2.3
-  rpm: bison >= 2.3
-  cmd: bison --version >= 2.3
-  pacman: bison >= 2.3
-source: wget+http://ftp.gnu.org/gnu/bison/bison-2.3.tar.gz
+  deb: bison >= 2.5
+  rpm: bison >= 2.5
+  cmd: bison --version >= 2.5
+  pacman: bison >= 2.5
+source: wget+http://ftp.gnu.org/gnu/bison/bison-2.5.tar.gz


### PR DESCRIPTION
Investigating #18 I noticed that apache-thrift needs bison 2.5 or higher:
```bash
$ ./configure
[...]
checking for bison... yes
checking for bison version >= 2.5... no
```