### PR TITLE
pkgconfig: source URL, configure call

### DIFF
--- a/pkg-config.lwr
+++ b/pkg-config.lwr
@@ -27,4 +27,6 @@ satisfy:
   rpm: (pkg-config >= 0.28)
   pacman: (pkg-config >= 0.28)
   port: pkgconfig >= 0.28
-source: wget+https://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz
+source: git+https://anongit.freedesktop.org/git/pkg-config.git
+gitrev: pkg-config-0.28
+configure: './autogen.sh ; ./configure --with-internal-glib --prefix=$prefix CC=$cc CXX=$cxx CXXFLAGS="-DNDEBUG"'


### PR DESCRIPTION
* https://freedesktop.org is giving urllib3/python-request trouble on CentOS7
  and other platforms with "older" Python 2.7 -> moved to git+https://
* configure script didn't specify to use built-in glib. Not pulling in
  glib as dependency unless strictly necessary, it needs a specific
  configure flag
* git checkouts are *not* identical to tarballs; need to call ./autogen.sh