### PR TITLE
Downgrading libtool version requirement

### DIFF
--- a/libtool.lwr
+++ b/libtool.lwr
@@ -24,8 +24,8 @@ depends:
 - automake
 inherit: autoconf
 satisfy:
-  deb: libtool >= 2.4.6
-  rpm: libtool >= 2.4.6
-  pacman: libtool >= 2.4.6
-  port: libtool >= 2.4.6
-source: wget+http://ftpmirror.gnu.org/libtool/libtool-2.4.6.tar.gz
+  deb: libtool >= 2.4.2
+  rpm: libtool >= 2.4.2
+  pacman: libtool >= 2.4.2
+  port: libtool >= 2.4.2
+source: wget+http://ftpmirror.gnu.org/libtool/libtool-2.4.2.tar.gz


### PR DESCRIPTION
For things to work without building this standard tool from source on
many rather modern RH/Fedora/CentOS distro's, we need to use 2.4.2
(which is the packaged version on CentOS 7, FC 22).

I haven't been able to find a package that actually requires >=2.4.6.

Since I've never built libtool locally to get any GR running, I'm positive this isn't necessary on Fedora.

On CentOS 7, I verified it's not necessary to build libtool from source for any of the dependent packages during a "gnuradio" installation.