### PR TITLE
pyqwt5: no longer attempting to install sip modules in /usr/share

### DIFF
--- a/pyqwt5.lwr
+++ b/pyqwt5.lwr
@@ -18,36 +18,18 @@
 #
 
 category: baseline
-configure: 'sed ''s/-lqwt/-lqwt-qt4/'' ../qwt-5.2/qwt.prf > ../qwt-5.2/qwt.prf.tmp
-  && \
-
-  cp ../qwt-5.2/qwt.prf.tmp ../qwt-5.2/qwt.prf && \
-
-  #python configure.py -I$prefix/include/qwt5/ -L$prefix/lib/ -L$prefix/lib64/ &&
-  \
-
-  python configure.py -Q ../qwt-5.2 --module-install-path=$prefix/lib/python2.6/site-packages/
-  -I$prefix/include/qwt5/ -L$prefix/lib/ -L$prefix/lib64
-
-  sed ''s/-lqwt/-lqwt-qt4/'' qwt5qt4/Makefile > qwt5qt4/Makefile.tmp && \
-
-  cp qwt5qt4/Makefile.tmp qwt5qt4/Makefile
-
-  sed ''s/\/usr\/share\/sip\//$prefix\/share\/sip\//'' qwt5qt4/Makefile > qwt5qt4/Makefile.tmp
-  && \
-
-  cp qwt5qt4/Makefile.tmp qwt5qt4/Makefile
-
-  mkdir -p $prefix/share/sip/PyQt4/Qwt5
-
-  sed ''s/\/usr\/lib64\/python2.6\/site-packages\/PyQt4\//$prefix\/lib\/python2.6\/site-packages\/PyQt4\//''
-  qwt5qt4/Makefile > qwt5qt4/Makefile.tmp && \
-
-  cp qwt5qt4/Makefile.tmp qwt5qt4/Makefile
-
-  mkdir -p $prefix/lib/python2.6/site-packages/PyQt4/uic/widget-plugins
-
-  '
+configure: " sed 's/-lqwt/-lqwt-qt4/' ../qwt-5.2/qwt.prf > ../qwt-5.2/qwt.prf.tmp &&
+  cp ../qwt-5.2/qwt.prf.tmp ../qwt-5.2/qwt.prf &&
+  python configure.py -Q ../qwt-5.2 --module-install-path=$prefix/lib/python2.7/site-packages/ -I$prefix/include/qwt5/ -L$prefix/lib/ -L$prefix/lib64 &&
+  sed 's/-lqwt/-lqwt-qt4/' qwt5qt4/Makefile > qwt5qt4/Makefile.tmp &&
+  cp qwt5qt4/Makefile.tmp qwt5qt4/Makefile &&
+  reprefix=$(python -c 'import os; import re; print re.escape(os.environ[\"PYBOMBS_PREFIX\"])') &&
+  sed 's/\\/usr\\/share\\/sip\\//'\"${reprefix}\"'\\/share\\/sip\\//' qwt5qt4/Makefile > qwt5qt4/Makefile.tmp &&
+  cp qwt5qt4/Makefile.tmp qwt5qt4/Makefile &&
+  mkdir -p $prefix/share/sip/PyQt4/Qwt5 &&
+  sed 's/\\/usr\\/lib64\\/python2.7\\/site-packages\\/PyQt4\\//'\"${reprefix}\"'\\/lib\\/python2.7\\/site-packages\\/PyQt4\\//' qwt5qt4/Makefile > qwt5qt4/Makefile.tmp &&
+  cp qwt5qt4/Makefile.tmp qwt5qt4/Makefile &&
+  mkdir -p $prefix/lib/python2.7/site-packages/PyQt4/uic/widget-plugins "
 configuredir: configure/
 depends:
 - qwt5


### PR DESCRIPTION
commit 4bf4e23 eliminated configure time dependency on the "reprefix"
environment variable, but did so in such a way that sip modulues are
installed under /usr/share instead of $PYBOMBS_PREFIX/share.  This
behavior is unintended and causes an error when pybombs is executed
by a non-root user.

This commit makes the following changes:
 * mirrors the "reprefix" fix applied to the qwt5 recipe in a38e3a5
 * fixes whitespace and formatting jank introduced by the
   convert_1to2.py conversion
 * changed python module directory for sed and for installation
   from "python2.6" to "python2.7".  This _should_ be safe since
   pybombs now requires python 2.7 to run

This resolves a CentOS 7 installation issue