### PR TITLE
added python-zmq as a dependency to gnuradio.lwr, otherwise flowgraphs wi…

### DIFF
--- a/gnuradio.lwr
+++ b/gnuradio.lwr
@@ -37,6 +37,7 @@ depends:
 - apache-thrift
 - liblog4cpp
 - zeromq
+- python-zmq
 category: common
 satisfy:
   deb: gnuradio-dev


### PR DESCRIPTION
added python-zmq as a dependency to gnuradio.lwr, otherwise flowgraphs with ZMQ blocks will fail at runtime.