### PR TITLE
add pacman sources to missing recipes

### DIFF
--- a/mcpp.lwr
+++ b/mcpp.lwr
@@ -32,6 +32,7 @@ satisfy:
   deb: (libmcpp-dev >= 2.7.2) && (mcpp >= 2.7.2)
   rpm: mcpp-devel >= 2.7.2
   port: mcpp >= 2.7.2
+  pacman: mcpp >= 2.7.2
 source:
 - file+dist/mcpp_2.7.2.orig.tar.gz
 - wget+http://aptproxy.willowgarage.com/archive.ubuntu.com/ubuntu/pool/universe/m/mcpp/mcpp_2.7.2.orig.tar.gz

--- a/mpc.lwr
+++ b/mpc.lwr
@@ -25,6 +25,7 @@ inherit: autoconf
 satisfy:
   deb: libmpc-dev >= 0.9
   port: libmpc >= 0.9
+  pacman: libmpc >= 0.9
 source: wget+http://www.multiprecision.org/mpc/download/mpc-0.9.tar.gz
 vars:
   config_opt: ' --with-gmp=$prefix '

--- a/mpfr.lwr
+++ b/mpfr.lwr
@@ -25,6 +25,7 @@ satisfy:
   deb: libmpfr-dev >= 3.0.0
   rpm: mpfr-devel >= 3.0.0
   port: mpfr >= 3.0.0
+  pacman: mpfr >= 3.0.0
 source: wget+http://www.mpfr.org/mpfr-3.0.0/mpfr-3.0.0.tar.gz
 vars:
   config_opt: ' --with-gmp-include=$prefix/include/ --with-gmp-lib=$prefix/lib/ '

--- a/networkx.lwr
+++ b/networkx.lwr
@@ -23,4 +23,5 @@ category: baseline
 satisfy:
   deb: python-networkx
   rpm: python-networkx
+  pacman: python2-networkx
   

--- a/osmo-sdr.lwr
+++ b/osmo-sdr.lwr
@@ -30,4 +30,5 @@ installdir: software/libosmosdr/build
 makedir: software/libosmosdr/build
 satisfy:
   deb: osmo-sdr && libosmosdr-dev
+  pacman: gnuradio-osmosdr
 source: git+git://git.osmocom.org/osmo-sdr.git

--- a/protobuf.lwr
+++ b/protobuf.lwr
@@ -23,4 +23,5 @@ satisfy:
   deb: libprotobuf-dev >= 2.6.1
   rpm: protobuf-devel >= 2.6.1
   port: protobuf-cpp >= 2.6.1 && py27-protobuf >= 2.6.1
+  pacman: protobuf >= 2.6.1
 source: wget+https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz

--- a/pulseaudio.lwr
+++ b/pulseaudio.lwr
@@ -23,3 +23,4 @@ satisfy:
   rpm: ((libpulse-devel >= 1.1) || (libpulseaudio-devel >= 1.1) || (pulseaudio-libs-devel
     >= 6.0) )
   port: pulseaudio
+  pacman: libpulse && pulseaudio

--- a/pygraphviz.lwr
+++ b/pygraphviz.lwr
@@ -22,4 +22,3 @@ category: baseline
 satisfy:
   deb: python-pygraphviz
   rpm: python-pygraphviz
-  

--- a/python-matplotlib.lwr
+++ b/python-matplotlib.lwr
@@ -26,3 +26,4 @@ satisfy:
   deb: python-matplotlib
   rpm: python-matplotlib
   port: py27-matplotlib
+  pacman: python2-matplotlib

--- a/rtl-sdr.lwr
+++ b/rtl-sdr.lwr
@@ -27,6 +27,7 @@ satisfy:
   deb: rtl-sdr && librtlsdr-dev
   port: rtl-sdr
   portage: net-wireless/rtl-sdr
+  pacman: rtl-sdr
 source: git+git://git.osmocom.org/rtl-sdr
 vars:
   config_opt: ' -DDETACH_KERNEL_DRIVER=ON '

--- a/wireshark.lwr
+++ b/wireshark.lwr
@@ -29,4 +29,5 @@ satisfy:
   deb: wireshark
   cmd: wireshark --version >= 1.0
   port: wireshark
+  pacman: wireshark-gtk
 source: wget+http://wiresharkdownloads.riverbed.com/wireshark/src/all-versions/wireshark-1.10.2.tar.bz2


### PR DESCRIPTION
As mentioned in previous PR I added pacman sources to some more recipes.
I used a diff of recipes containing deb: lines but no pacman lines. Maybe this reduces compile time for Arch users :)