### PR TITLE
Update name of python-zmq for rpm distributions

### DIFF
--- a/python-zmq.lwr
+++ b/python-zmq.lwr
@@ -20,6 +20,6 @@
 category: baseline
 satisfy:
   deb: python-zmq
-  rpm: python-zmq
+  rpm: python-zmq || python2-zmq
   port: py27-zmq
   pacman: python2-pyzmq


### PR DESCRIPTION
Fedora 24 renamed "python-zmq" to "python2-zmq".  This change will try the old name first, then "python2-zmq".