### PR TITLE
Update libiio and gr-iio

### DIFF
--- a/gr-iio.lwr
+++ b/gr-iio.lwr
@@ -22,9 +22,11 @@ depends:
 - gnuradio
 - libiio
 - libad9361
+- flex
+- bison
 description: GNU Radio IIO Blocks
-gitbranch: gr-iio
+gitrev: tags/v0.2
 inherit: cmake
 satisfy:
-  deb: gr-iio
-source: git+https://github.com/analogdevicesinc/gnuradio.git
+  deb: gr-iio >= 0.2
+source: git+https://github.com/analogdevicesinc/gr-iio.git

--- a/libiio.lwr
+++ b/libiio.lwr
@@ -20,13 +20,14 @@
 category: hardware
 depends:
 - libxml
+- libusb
 - cmake
 - git
 description: Library for interfacing with IIO devices
-gitrev: 2015_R1
+gitrev: tags/v0.7
 inherit: cmake
 satisfy:
-  deb: libiio0 >= 0.5 && libiio-dev >= 0.5
+  deb: libiio0 >= 0.7 && libiio-dev >= 0.7
 source: git+https://github.com/analogdevicesinc/libiio
 vars:
   config_opt: ' -DWITH_IIOD:BOOL=OFF '


### PR DESCRIPTION
Libiio v0.7 brings USB support, and is overall more stable.
The gr-iio recipe was pointing to the wrong git repository. This was fixed in recipes-legacy, but apparently didn't make it here. The version 0.2 brings a couple more blocks including the 'iio_math' and 'iio_math_gen' blocks.