### PR TITLE
openSUSE and virtualenv recipes

### DIFF
--- a/alsa.lwr
+++ b/alsa.lwr
@@ -21,7 +21,7 @@ category: baseline
 inherit: autoconf
 satisfy:
   deb: libasound2-dev
-  rpm: alsa-lib-devel
+  rpm: alsa-lib-devel || alsa-devel
   pacman: alsa-lib
   port: portaudio
   portage: media-libs/portaudio

--- a/boost.lwr
+++ b/boost.lwr
@@ -28,7 +28,7 @@ install_static: 'cd .. && ./bjam cxxflags=''-fPIC'' --threading=multi --layout=t
   '
 satisfy:
   deb: libboost-all-dev >= 1.53 || libboost-dev >= 1.53
-  rpm: boost-devel >= 1.53
+  rpm: (boost-devel >= 1.53) || (boost_1_61-devel >= 1.53)
   pacman: boost >= 1.53
   port: boost >= 1.53
   portage: dev-libs/boost >= 1.53

--- a/cheetah.lwr
+++ b/cheetah.lwr
@@ -28,6 +28,7 @@ satisfy:
   cmd: cheetah --version >= 2.0
   port: py27-cheetah >= 2.0
   portage: dev-python/cheetah >= 2.0
+  pip: Cheetah >= 2.0
 source:
   - git+https://github.com/cheetahtemplate/cheetah.git
   - wget+http://prdownloads.sourceforge.net/cheetahtemplate/Cheetah-2.0.1.tar.gz

--- a/ffi.lwr
+++ b/ffi.lwr
@@ -24,7 +24,7 @@ depends:
 inherit: autoconf
 satisfy:
   deb: libffi6
-  rpm: libffi-devel
+  rpm: libffi-devel || libffi-devel-gcc5
   pacman: libffi
   port: libffi
 source: wget+https://www.mirrorservice.org/sites/sourceware.org/pub/libffi/libffi-3.0.9.tar.gz

--- a/fftw.lwr
+++ b/fftw.lwr
@@ -21,7 +21,7 @@ category: baseline
 inherit: autoconf
 satisfy:
   deb: libfftw3-3 && libfftw3-dev
-  rpm: fftw-devel
+  rpm: fftw-devel || fftw3-devel
   pacman: fftw
   port: fftw-3-single
   pkgconfig: fftw3

--- a/libbzip.lwr
+++ b/libbzip.lwr
@@ -21,7 +21,7 @@ category: baseline
 source: wget+https://launchpad.net/ubuntu/+archive/primary/+files/bzip2_1.0.6.orig.tar.bz2
 satisfy:
   deb: libbz2-dev
-  rpm: bzip2-devel
+  rpm: bzip2-devel || 
   port: libzip
   pacman: libzip
 inherit: autoconf

--- a/libjpeg.lwr
+++ b/libjpeg.lwr
@@ -21,6 +21,6 @@ category: baseline
 depends: null
 satisfy:
   deb: libjpeg-turbo8-dev || libjpeg62-dev || libjpeg62-turbo-dev
-  rpm: libjpeg-devel || libjpeg-turbo-devel
+  rpm: libjpeg-devel || libjpeg-turbo-devel || libjpeg8-devel || libjpeg62-devel
   pacman: libjpeg-turbo
   port: jpeg

--- a/libpng.lwr
+++ b/libpng.lwr
@@ -21,7 +21,7 @@ category: baseline
 inherit: autoconf
 satisfy:
   deb: libpng12-dev >= 1.2.41
-  rpm: libpng-devel >= 1.2.41
+  rpm: (libpng-devel >= 1.2.41) || (libpng12-devel >= 1.2.41)
   pacman: libpng
   port: libpng >= 1.2.41
 source: wget+https://launchpad.net/ubuntu/+archive/primary/+files/libpng_1.2.42.orig.tar.bz2

--- a/lxml.lwr
+++ b/lxml.lwr
@@ -28,7 +28,6 @@ satisfy:
   deb: python-lxml >= 2.3.2
   rpm: python2-lxml >= 2.3.2 || python-lxml >= 2.3.2
   pacman: python2-lxml >= 2.3.2
-  pip: lxml
   port: py27-lxml >= 2.3.2
   portage: dev-python/lxml >= 2.3.2
   pip: lxml >= 2.3.2

--- a/lxml.lwr
+++ b/lxml.lwr
@@ -26,8 +26,9 @@ depends:
 inherit: distutils
 satisfy:
   deb: python-lxml >= 2.3.2
-  rpm: python2-lxml || python-lxml >= 2.3.2
+  rpm: python2-lxml >= 2.3.2 || python-lxml >= 2.3.2
   pacman: python2-lxml >= 2.3.2
+  pip: lxml
   port: py27-lxml >= 2.3.2
   portage: dev-python/lxml >= 2.3.2
 source: wget+http://lxml.de/files/lxml-2.3.3.tgz

--- a/lxml.lwr
+++ b/lxml.lwr
@@ -31,4 +31,5 @@ satisfy:
   pip: lxml
   port: py27-lxml >= 2.3.2
   portage: dev-python/lxml >= 2.3.2
+  pip: lxml >= 2.3.2
 source: wget+http://lxml.de/files/lxml-2.3.3.tgz

--- a/lxml.lwr
+++ b/lxml.lwr
@@ -26,7 +26,7 @@ depends:
 inherit: distutils
 satisfy:
   deb: python-lxml >= 2.3.2
-  rpm: python-lxml >= 2.3.2
+  rpm: python2-lxml || python-lxml >= 2.3.2
   pacman: python2-lxml >= 2.3.2
   port: py27-lxml >= 2.3.2
   portage: dev-python/lxml >= 2.3.2

--- a/numpy.lwr
+++ b/numpy.lwr
@@ -26,7 +26,7 @@ inherit: distutils
 satisfy:
   pip: numpy >= 1.5
   deb: python-numpy >= 1.5
-  rpm: numpy >= 1.5
+  rpm: numpy >= 1.5 || python-numpy >= 1.5
   pacman: python2-numpy >= 1.5
   port: py27-numpy >= 1.5
   portage: dev-python/numpy >= 1.5

--- a/pixman.lwr
+++ b/pixman.lwr
@@ -21,7 +21,7 @@ category: baseline
 inherit: autoconf
 satisfy:
   deb: (libpixman-1-0 >= 0.18.4) || (libpixman-1-dev >= 0.18.4)
-  rpm: pixman-devel >= 0.18.4
+  rpm: (pixman-devel >= 0.18.4) || (libpixman-1-0-devel >= 0.18.4)
   pacman: pixman
   port: libpixman >= 0.18.4
 source: wget+https://launchpad.net/ubuntu/+archive/primary/+files/pixman_0.18.4.orig.tar.gz

--- a/pkg-config.lwr
+++ b/pkg-config.lwr
@@ -20,7 +20,7 @@
 category: baseline
 satisfy:
   deb: pkg-config
-  rpm: pkgconfig
+  rpm: pkgconfig || pkg-config
   pacman: pkg-config
   port: pkgconfig
   portage: dev-util/pkgconfig

--- a/pycairo.lwr
+++ b/pycairo.lwr
@@ -27,9 +27,10 @@ install_like: cairo
 make: ./waf build
 satisfy:
   deb: python-cairo-dev >= 1.8
-  rpm: pycairo-devel >= 1.8
+  rpm: (pycairo-devel >= 1.8) || (python-cairo-devel >= 1.8)
   pacman: python2-cairo >= 1.8
   port: py27-cairo >= 1.8
   portage: dev-python/pycairo >= 1.8
   python: cairo.version >= 1.8
+  pip: pycairo >= 1.8
 source: wget+http://cairographics.org/releases/py2cairo-1.8.10.tar.gz

--- a/pycairo.lwr
+++ b/pycairo.lwr
@@ -35,4 +35,5 @@ satisfy:
   python: cairo.version >= 1.8
   pip: pycairo >= 1.8
 #source: wget+http://cairographics.org/releases/py2cairo-1.8.10.tar.gz
-source: git://git.cairographics.org/git/py2cairo
+source: git+git://git.cairographics.org/git/py2cairo
+configure: sh ./autogen.sh --prefix=$prefix

--- a/pycairo.lwr
+++ b/pycairo.lwr
@@ -18,13 +18,14 @@
 #
 
 category: baseline
-configure: ./waf configure --prefix=$prefix
+#configure: ./waf configure --prefix=$prefix
 depends:
 - cairo
 - python
-install: ./waf install
+#install: ./waf install
 install_like: cairo
-make: ./waf build
+#make: ./waf build
+inherit: autoconf
 satisfy:
   deb: python-cairo-dev >= 1.8
   rpm: (pycairo-devel >= 1.8) || (python-cairo-devel >= 1.8)
@@ -33,4 +34,5 @@ satisfy:
   portage: dev-python/pycairo >= 1.8
   python: cairo.version >= 1.8
   pip: pycairo >= 1.8
-source: wget+http://cairographics.org/releases/py2cairo-1.8.10.tar.gz
+#source: wget+http://cairographics.org/releases/py2cairo-1.8.10.tar.gz
+source: git://git.cairographics.org/git/py2cairo

--- a/pygobject.lwr
+++ b/pygobject.lwr
@@ -27,9 +27,10 @@ inherit: autoconf
 install_like: gobject-introspection
 satisfy:
   deb: python-gobject-dev >= 2.27
-  rpm: pygobject2-devel >= 2.27
+  rpm: (pygobject2-devel >= 2.27) || (python-gobject2-devel >= 2.27)
   pacman: python2-gobject2 >= 2.27
   port: py27-gobject >= 2.27
-source: wget+http://ftp.gnome.org/pub/GNOME/sources/pygobject/2.27/pygobject-2.27.91.tar.gz
+  pip: PyGObject >= 2.27
+source: wget+http://ftp.gnome.org/pub/GNOME/sources/pygobject/2.28/pygobject-2.28.6.tar.bz2
 vars:
-  config_opt: ' --enable-introspection '
+  config_opt: ' --disable-introspection '

--- a/pygobject.lwr
+++ b/pygobject.lwr
@@ -21,7 +21,7 @@ category: baseline
 depends:
 - python
 - swig
-- gobject-introspection
+#- gobject-introspection
 - gtk2
 inherit: autoconf
 install_like: gobject-introspection

--- a/pygtk.lwr
+++ b/pygtk.lwr
@@ -29,8 +29,9 @@ inherit: autoconf
 install_like: gtk2
 satisfy:
   deb: python-gtk2 >= 2.17
-  rpm: pygtk2-devel >= 2.17
+  rpm: pygtk2-devel >= 2.17 || python-gtk-devel >= 2.17
   pacman: pygtk >= 2.17
   port: py27-pygtk >= 2.17
   portage: dev-python/pygtk >= 2.17
-source: wget+http://ftp.gnome.org/pub/GNOME/sources/pygtk/2.17/pygtk-2.17.0.tar.bz2
+  pip: PyGTK >= 2.17
+source: wget+http://ftp.gnome.org/pub/GNOME/sources/pygtk/2.24/pygtk-2.24.0.tar.bz2

--- a/pyqt4.lwr
+++ b/pyqt4.lwr
@@ -18,7 +18,7 @@
 #
 
 category: baseline
-configure: python configure.py --confirm-license -b $prefix/bin -d $prefix/lib/python2.6/site-packages/ -v $prefix/share/sip/
+configure: python configure.py --confirm-license -b $prefix/bin -d $prefix/lib/python2.7/site-packages/ -v $prefix/share/sip/ --no-designer-plugin CXXFLAGS+=-Wno-narrowing
 depends:
 - python
 - sip
@@ -27,8 +27,9 @@ inherit: autoconf
 install_like: qt4
 satisfy:
   deb: ( python-qt4 >= 4.6.2 ) && ( pyqt4-dev-tools >= 4.6.2 )
-  rpm: PyQt4-devel >= 4.6.2
+  rpm: PyQt4-devel >= 4.6.2 || python-qt4-devel >= 4.6.2
   pacman: python2-pyqt4
   port: py27-pyqt4 >= 4.6.2
   portage: dev-python/PyQt4 >= 4.6.2
+#  pip: PyQt4 >= 4.6.2
 source: wget+http://pkgs.fedoraproject.org/repo/pkgs/PyQt4/PyQt-x11-gpl-4.7.2.tar.gz/e7782e9146ec8aa0e76bcdb0ca5b9491/PyQt-x11-gpl-4.7.2.tar.gz

--- a/pyqwt5.lwr
+++ b/pyqwt5.lwr
@@ -45,4 +45,5 @@ satisfy:
   pacman: qwt5 >= 5.2
   port: py27-pyqwt >= 5.2
   portage: dev-python/pyqwt >= 5.2
+  pip: PythonQwt
 source: wget+http://sourceforge.net/projects/pyqwt/files/pyqwt5/PyQwt-5.2.0/PyQwt-5.2.0.tar.gz

--- a/python-tk.lwr
+++ b/python-tk.lwr
@@ -23,5 +23,5 @@ depends:
 description: A module for writing portable GUI applications with Python using Tk.
 satisfy:
   deb: python-tk
-  rpm: python-tkinter
+  rpm: python-tkinter || python-tk
   port: py27-tkinter

--- a/python-zmq.lwr
+++ b/python-zmq.lwr
@@ -20,8 +20,9 @@
 category: baseline
 satisfy:
   deb: python-zmq
-  rpm: python-zmq || python2-zmq
+  rpm: python-zmq || python2-zmq || python-pyzmq
   port: py27-zmq
   pacman: python2-pyzmq
   portage: dev-python/pyzmq
   python: zmq
+  pip: pyzmq

--- a/python.lwr
+++ b/python.lwr
@@ -22,7 +22,7 @@ inherit: autoconf
 satisfy:
   deb: python2.7 && python-dev
   rpm: python-devel >= 2.7
-  cmd: python --version >= 2.7
+#  cmd: python --version >= 2.7
   pacman: python2 >= 2.7
   port: python27 >= 2.7
   portage: dev-lang/python >= 2.7

--- a/qt4.lwr
+++ b/qt4.lwr
@@ -21,7 +21,7 @@ category: baseline
 inherit: autoconf
 satisfy:
   deb: libqt4-dev >= 4.6.2
-  rpm: qt-devel >= 4.6.2 || qt4-devel >= 4.6.2
+  rpm: qt-devel >= 4.6.2 || qt4-devel >= 4.6.2 || libqt4-devel >= 4.6.2
   pacman: qt4 >= 4.6.2
   port: qt4-mac >= 4.6.2
 source: wget+https://download.qt.io/archive/qt/4.6/qt-everywhere-opensource-src-4.6.2.tar.gz

--- a/qt5.lwr
+++ b/qt5.lwr
@@ -20,6 +20,6 @@
 category: baseline
 satisfy:
   deb: libqt5svg5-dev && qt5-default
-  rpm: qt5-qtbase-devel && qt5-qtsvg-devel
+  rpm: (qt5-qtbase-devel && qt5-qtsvg-devel) || (devel_qt5 && libqt5-qtsvg-devel)
   pacman: qt5-base
   port: qt5 && qt5-qtbase

--- a/scipy.lwr
+++ b/scipy.lwr
@@ -25,8 +25,9 @@ depends:
 inherit: distutils
 satisfy:
   deb: python-scipy >= 0.8
-  rpm: scipy
+  rpm: scipy || python-scipy
   pacman: python2-scipy >= 0.8
   port: py27-scipy >= 0.8
   python: scipy >= 0.8
+  pip: scipy >= 0.8
 source: wget+http://downloads.sourceforge.net/project/scipy/scipy/0.8.0/scipy-0.8.0.tar.gz

--- a/setuptools.lwr
+++ b/setuptools.lwr
@@ -25,4 +25,5 @@ satisfy:
   rpm: python-setuptools >= 0.6
   pacman: python2-setuptools >= 0.6
   port: py27-setuptools >= 0.6
+  pip: setuptools >= 0.6
 source: wget+https://pypi.python.org/packages/source/s/setuptools/setuptools-0.6c11.tar.gz

--- a/sip.lwr
+++ b/sip.lwr
@@ -18,18 +18,16 @@
 #
 
 category: baseline
-configure: 'python configure.py -b $prefix/bin -e $prefix/include/ -d $prefix/lib/python2.6/site-packages/
-  -v $prefix/share/sip/
-
-  '
+configure: 'python configure.py -b $prefix/bin -e $prefix/include/python2.7 -d $prefix/lib/python2.7/site-packages/ -v $prefix/share/sip/ INCDIR=$prefix/include/python2.7'
 depends:
 - python
 inherit: autoconf
 install_like: python
 satisfy:
   deb: python-sip-dev >= 4.10.1
-  rpm: sip-devel >= 4.10.1
+  rpm: sip-devel >= 4.10.1 || python-sip-devel >= 4.10.1
   pacman: python2-sip >= 4.10.1
   port: py27-sip >= 4.10.1
   python: sip.SIP_VERSION_STR >= 4.10.1
+  pip: SIP
 source: wget+http://pkgs.fedoraproject.org/repo/pkgs/sip/sip-4.10.1.tar.gz/9fa0b0d17ad355bde004317f67c819f9/sip-4.10.1.tar.gz

--- a/ssl.lwr
+++ b/ssl.lwr
@@ -20,7 +20,7 @@
 category: baseline
 satisfy:
   deb: libssl-dev
-  rpm: openssl-devel
+  rpm: openssl-devel || libopenssl-devel
   pacman: openssl
   port: openssl
   portage: dev-libs/openssl

--- a/twisted.lwr
+++ b/twisted.lwr
@@ -21,9 +21,10 @@ category: baseline
 depends: null
 satisfy:
   deb: python-twisted || python-twisted-core
-  rpm: python2-twisted || python-twisted || python-twisted-core
+  rpm: python2-twisted || python-twisted || python-twisted-core || python-Twisted
   pacman: python2-twisted
   cmd: trial
   port: py27-twisted
   portage: dev-python/twisted-core
   python: twisted
+  pip: Twisted

--- a/twisted.lwr
+++ b/twisted.lwr
@@ -18,7 +18,8 @@
 #
 
 category: baseline
-depends: null
+depends:
+- python
 satisfy:
   deb: python-twisted || python-twisted-core
   rpm: python2-twisted || python-twisted || python-twisted-core || python-Twisted

--- a/twisted.lwr
+++ b/twisted.lwr
@@ -21,7 +21,7 @@ category: baseline
 depends: null
 satisfy:
   deb: python-twisted || python-twisted-core
-  rpm: python-twisted || python-twisted-core
+  rpm: python2-twisted || python-twisted || python-twisted-core
   pacman: python2-twisted
   cmd: trial
   port: py27-twisted

--- a/wxpython.lwr
+++ b/wxpython.lwr
@@ -40,8 +40,9 @@ make: 'make && \
 
   '
 satisfy:
+  pip: wxPython
   deb: python-wxgtk2.8 || python-wxgtk3.0
-  rpm: wxPython
+  rpm: wxPython || python-wxWidgets-3_0-devel
   port: wxPython-3.0 && py27-wxpython-3.0
   portage: dev-python/wxpython
   pacman: wxpython

--- a/zeromq.lwr
+++ b/zeromq.lwr
@@ -23,7 +23,7 @@ depends:
 inherit: autoconf
 satisfy:
   deb: libzmq3-dev
-  rpm: cppzmq-devel
+  rpm: cppzmq-devel || czmq-devel
   pacman: zeromq
   port: cppzmq
   portage: net-libs/cppzmq


### PR DESCRIPTION
The openSUSE linux distribution uses rpm packages but a different naming convention than does Redhat.  This pull request adds openSUSE specific packages to the rpm satisfy field.

(Apologies for combining two ostensibly independent submissions, they were developed jointly.)

Python virtual environments (venvs) allow users to create somewhat isolated installations of python on a single machine.  These venvs allow a user to have a variety of python module support and versioning appropriate to their specific project or application.  It also allows the developer to experiment with modules without the risk of causing a conflict within his base OS, which may use particular python utilities or library versions.  This can be especially important when creating minimal environments for deployment.  

In order for a venv to be independent, every python package must be installed via pip or source.  In some cases, notably pyqt, pycairo, pygobject, and pygtk, a pip install will fail and a source build must be executed.  In the case of twisted, the pip install will only work with proper setup.  It would be nice to be able to limit the packagers to a subset of those available for individual recipes or categories.  In the latter case, it would be nice to have a virtualenv category that included all of the python recipes and restricted packagers to pip and source.

The changes to pyqt4, pycairo, pygobject, and pygtk were necessary due to an incompatibility between gobject-introspection 0.10 and pygobject.  The current configuration may not be the only one that works, but it's the one I was able to get to work first.  

For the Twisted install, pip will build from source but requires python development files (particularly Python.h).  These do not exist in the virtualenv even if the correct system package (e.g. python-devel) is installed.  I worked around this by temporarily overlaying the venv include subtree on top of the system include subtree.  My command:

$ sudo mount -t overlay -o lowerdir=/usr/include/python2.7,\ upperdir=$VIRTUAL_ENV/include/python2.7,workdir=$HOME/work overlay $VIRTUAL_ENV/include/python2.7

where the environment variables are somewhat self-explanatory.

I do not know if this is completely necessary or if a sym link to Python.h would have been enough.  One wrinkle is that the cmd satisfy option in python.lwr looks for the python interpreter version when it should be looking for files included in the python-devel packages, e.g. python-config utility.  Otherwise, the cmd option returns true when the development files are actually missing.  Making this work in a virtualenv will be a little tricky and I have not solved that yet.
