### PR TITLE
x11: Fix deb package case error.

### DIFF
--- a/x11.lwr
+++ b/x11.lwr
@@ -20,7 +20,7 @@
 category: baseline
 depends: null
 satisfy:
-  deb: libx11-dev && libxrender-dev
+  deb: (libx11-dev || libX11-dev) && libxrender-dev
   rpm: libX11-devel && libXrender-devel && libXext-devel
   pacman: libx11 && libxrender
   port: xorg-libX11


### PR DESCRIPTION
This commit is to fix issue #77 on Debian based systems.