### PR TITLE
the 'gr-drm/' prefix is no longer necessary

### DIFF
--- a/gr-drm.lwr
+++ b/gr-drm.lwr
@@ -18,7 +18,6 @@
 #
 
 category: common
-configuredir: gr-drm/build
 depends:
 - gnuradio
 - uhd
@@ -28,6 +27,4 @@ depends:
 description: DRM transmitter using GNU Radio
 gitbranch: master
 inherit: cmake
-installdir: gr-drm/build
-makedir: gr-drm/build
 source: git+https://github.com/kit-cel/gr-drm.git


### PR DESCRIPTION
Probably because of repo restructuring in
https://github.com/kit-cel/gr-drm/commit/5c2dfaa4a96f5e8c7bd4f468fc8ef79a3d9e2d0e

Fixes build.