### PR TITLE
Added gr-finite-stream

### DIFF
--- a/gr-finite-stream.lwr
+++ b/gr-finite-stream.lwr
@@ -1,0 +1,26 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends:
+- gnuradio
+description: Blocks for handling finite-length streams
+gitbranch: master
+inherit: cmake
+source: git+https://github.com/rubund/gr-finite-stream.git


### PR DESCRIPTION
This comes out of the discussion here: https://github.com/gnuradio/gnuradio/pull/1295

The idea is that gr-finite-stream should contain blocks which detect the end of incoming input streams and do useful things. Currently there is only a concatenate block which does as described here:

The block takes the input from several sources and put all the items
after each other. All the items from the source connected to the
first input are produced first, then all the items from the second
source, and so on. The upstream blocks need to return -1 in the
general_work method to make this block aware of when they have
completed producing items.

It can be useful for appending a vector (vector_source) to the end of a file
(file_source), appending one file to another file etc.


A repeat_stream block is also under way.



