### PR TITLE
Adding pyqt5 recipe

### DIFF
--- a/pyqt5.lwr
+++ b/pyqt5.lwr
@@ -1,0 +1,34 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: baseline
+configure: python configure.py --confirm-license -b $prefix/bin -d $prefix/lib/python2.6/site-packages/ -v $prefix/share/sip/
+depends:
+- python
+- sip
+- qt5
+inherit: autoconf
+install_like: qt5
+satisfy:
+  deb: ( pyqt5-dev >= 5.3.2 ) && ( pyqt5-dev-tools >= 5.3.2 )
+  rpm: ( python-qt5 >= 5.8.2 ) && ( python-qt5-devel >= 5.8.2 )
+  pacman: python-pyqt5
+  port: py27-qt5 >= 5.7.1
+  portage: dev-python/PyQt5 >= 5.7.1
+source: wget+https://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.8.2/PyQt5_gpl-5.8.2.tar.gz


### PR DESCRIPTION
A recent change in one GUI tool from Ettus Research (uhd_image_builder_gui.py) requires PyQt5, so I'm adding this to have it as a dependency for the RFNOC recipe in the Ettus' recipes repository