### PR TITLE
pyqt5: fix fedora build and source version

### DIFF
--- a/pyqt5.lwr
+++ b/pyqt5.lwr
@@ -27,8 +27,8 @@ inherit: autoconf
 install_like: qt5
 satisfy:
   deb: ( pyqt5-dev >= 5.3.2 ) && ( pyqt5-dev-tools >= 5.3.2 )
-  rpm: ( python-qt5 >= 5.8.2 ) && ( python-qt5-devel >= 5.8.2 )
+  rpm: python-qt5 && python-qt5-devel
   pacman: python-pyqt5
   port: py27-qt5 >= 5.7.1
   portage: dev-python/PyQt5 >= 5.7.1
-source: wget+https://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.8.2/PyQt5_gpl-5.8.2.tar.gz
+source: wget+https://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.6/PyQt5_gpl-5.6.tar.gz


### PR DESCRIPTION
Briefly:
- The versioning scheme the recipe has for rpm was not being picked up correctly, so the build system was going directly for source install
- The version for the source tarball that the recipe had required a new sip version, which is not installed as a requirement. Rolling back a couple of versions to another stable tarball seems to do the trick (as per the sip installation from the recipe that pybombs also provides)

I had to do something extra for the source installation, I describe as follows in case someone can give me a lead. I'm not sure if this step can be added to the recipe:

The source installation also required qmake (which comes with qt5). I had to explicitly add that to the path:
    $ cd /
    $ find -iname qmake

and add the location where it was found:

    $ export PATH=$PATH:/usr/lib64/qt5/bin/

And then the installation runs successfully.
