### PR TITLE
On Fedora 26 install python2-* packages

### DIFF
--- a/networkx.lwr
+++ b/networkx.lwr
@@ -22,6 +22,6 @@ depends:
 category: baseline
 satisfy:
   deb: python-networkx
-  rpm: python-networkx
+  rpm: python-networkx || python2-networkx
   pacman: python2-networkx
   

--- a/pygraphviz.lwr
+++ b/pygraphviz.lwr
@@ -21,4 +21,4 @@ depends: null
 category: baseline
 satisfy:
   deb: python-pygraphviz
-  rpm: python-pygraphviz
+  rpm: python-pygraphviz || python2-pygraphviz

--- a/python-matplotlib.lwr
+++ b/python-matplotlib.lwr
@@ -24,7 +24,7 @@ depends:
 description: Python based plotting system in a style similar to Matlab.
 satisfy:
   deb: python-matplotlib
-  rpm: python-matplotlib
+  rpm: python-matplotlib || python2-matplotlib
   port: py27-matplotlib
   pacman: python2-matplotlib
   python: matplotlib

--- a/python-tk.lwr
+++ b/python-tk.lwr
@@ -23,5 +23,5 @@ depends:
 description: A module for writing portable GUI applications with Python using Tk.
 satisfy:
   deb: python-tk
-  rpm: python-tkinter || python-tk
+  rpm: python-tkinter || python-tk || python2-tkinter
   port: py27-tkinter

--- a/python.lwr
+++ b/python.lwr
@@ -21,7 +21,7 @@ category: baseline
 inherit: autoconf
 satisfy:
   deb: python2.7 && python-dev
-  rpm: python-devel >= 2.7
+  rpm: python-devel >= 2.7 || python2-devel >= 2.7
 #  cmd: python --version >= 2.7
   pacman: python2 >= 2.7
   port: python27 >= 2.7

--- a/scipy.lwr
+++ b/scipy.lwr
@@ -25,7 +25,7 @@ depends:
 inherit: distutils
 satisfy:
   deb: python-scipy >= 0.8
-  rpm: scipy || python-scipy
+  rpm: scipy || python-scipy || python2-scipy
   pacman: python2-scipy >= 0.8
   port: py27-scipy >= 0.8
   python: scipy >= 0.8

--- a/setuptools.lwr
+++ b/setuptools.lwr
@@ -22,7 +22,7 @@ depends:
 - python
 satisfy:
   deb: python-setuptools >= 0.6
-  rpm: python-setuptools >= 0.6
+  rpm: python-setuptools >= 0.6 || python2-setuptools >= 0.6
   pacman: python2-setuptools >= 0.6
   port: py27-setuptools >= 0.6
   pip: setuptools >= 0.6

--- a/six.lwr
+++ b/six.lwr
@@ -23,7 +23,7 @@ depends:
 inherit: distutils
 satisfy:
   deb: python-six >= 1.0
-  rpm: python-six >= 1.0
+  rpm: python-six >= 1.0 || python2-six >= 1.0
   pip: six
   pacman: python2-six >= 1.0
   port: py27-six >= 1.0


### PR DESCRIPTION
On Fedora 26 the gnuradio build fails because several python packages are available only with python2 prefix