### PR TITLE
add rpm to sqlite

### DIFF
--- a/sqlite.lwr
+++ b/sqlite.lwr
@@ -21,3 +21,5 @@ category: baseline
 depends: null
 satisfy:
   deb: libsqlite3-dev
+  rpm: sqlite-devel
+

--- a/sqlite.lwr
+++ b/sqlite.lwr
@@ -22,4 +22,3 @@ depends: null
 satisfy:
   deb: libsqlite3-dev
   rpm: sqlite-devel
-


### PR DESCRIPTION
this fixes pybombs usage on fedora based systems. To find the sqlite package