### PR TITLE
libosmocore depends on gnutls

### DIFF
--- a/libosmocore.lwr
+++ b/libosmocore.lwr
@@ -28,6 +28,7 @@ depends:
 - automake
 - pcsclite
 - libtalloc-dev
+- gnutls
 description: A library with generic ulitity functions developed by Osmocom project
 gitbranch: master
 inherit: autoconf


### PR DESCRIPTION
It depends on gnutls since commit ed029dfab and ./configure fails when
not found and not disabled explicitly

https://github.com/osmocom/libosmocore/blob/ed029dfab/configure.ac#L133-L145