### PR TITLE
Update apache-thrift to 0.10.0

### DIFF
--- a/apache-thrift.lwr
+++ b/apache-thrift.lwr
@@ -37,7 +37,7 @@ depends:
 - ssl
 - pkg-config
 - twisted
-gitrev: 0.9.3
+gitrev: 0.10.0
 inherit: bootstrapautoconf
 source: git+https://github.com/apache/thrift.git
 satisfy:


### PR DESCRIPTION
On latest _stable_ distros (e.g. Debian 9 Stretch, Fedora 26, possibly Ubuntu 16/17), apache-thrift 0.9.3 will fail to build (unable to find libcrypto). This change worked for me on Debian 9.