### PR TITLE
add dependency on pybitarray to gr-burst, gr-psk-burst

### DIFF
--- a/gr-burst.lwr
+++ b/gr-burst.lwr
@@ -22,6 +22,7 @@ depends:
 - gnuradio
 - gr-mapper
 - gr-eventstream
+- pybitarray
 description: Burst PSK Modem Building Blocks for GNU Radio
 gitbranch: master
 inherit: cmake

--- a/pybitarray.lwr
+++ b/pybitarray.lwr
@@ -17,16 +17,11 @@
 # Boston, MA 02110-1301, USA.
 #
 
-category: common
+category: baseline
 depends:
-- gnuradio
-- gr-burst
-- gr-mapper
-- gr-eventstream
-- gr-pyqt
-- scipy
-- pybitarray
-description: GNU Radio message based burst PSK Transmitter and Receiver
-gitbranch: master
-inherit: empty
-source: git+https://github.com/osh/gr-psk-burst.git
+- python
+satisfy:
+  deb: python-bitarray
+  rpm: python2-bitarray
+  port: pybitarray
+  pip: bitarray


### PR DESCRIPTION
First time working with pybombs and gr-recipes, so let me know if there is more work/testing I need to do. `pybombs install gr-psk-burst gr-burst` works at install, but the various blocks fail at runtime with a missing bitarray module. This change should fix that.