### PR TITLE
Add more SoapySDR modules.

### DIFF
--- a/airspyhf.lwr
+++ b/airspyhf.lwr
@@ -20,11 +20,7 @@
 category: hardware
 depends:
 - libusb
-description: Host side software for AirSpy dongles
+description: User mode driver for Airspy HF+
 gitbranch: master
 inherit: cmake
-satisfy:
-  deb: airspy
-  port: airspy
-  pacman: airspy
-source: git+https://github.com/airspy/airspyone_host.git
+source: git+https://github.com/airspy/airspyhf.git

--- a/soapyairspy.lwr
+++ b/soapyairspy.lwr
@@ -19,12 +19,9 @@
 
 category: hardware
 depends:
-- libusb
-description: Host side software for AirSpy dongles
+- soapysdr
+- airspy
+description: Soapy SDR module for Airspy
 gitbranch: master
 inherit: cmake
-satisfy:
-  deb: airspy
-  port: airspy
-  pacman: airspy
-source: git+https://github.com/airspy/airspyone_host.git
+source: git+https://github.com/pothosware/SoapyAirspy.git

--- a/soapyairspyhf.lwr
+++ b/soapyairspyhf.lwr
@@ -19,12 +19,9 @@
 
 category: hardware
 depends:
-- libusb
-description: Host side software for AirSpy dongles
+- soapysdr
+- airspyhf
+description: Soapy SDR module for Airspy HF+
 gitbranch: master
 inherit: cmake
-satisfy:
-  deb: airspy
-  port: airspy
-  pacman: airspy
-source: git+https://github.com/airspy/airspyone_host.git
+source: git+https://github.com/pothosware/SoapyAirspyHF.git

--- a/soapybladerf.lwr
+++ b/soapybladerf.lwr
@@ -19,12 +19,9 @@
 
 category: hardware
 depends:
-- libusb
-description: Host side software for AirSpy dongles
+- soapysdr
+- bladeRF
+description: Soapy SDR module for BladeRF
 gitbranch: master
 inherit: cmake
-satisfy:
-  deb: airspy
-  port: airspy
-  pacman: airspy
-source: git+https://github.com/airspy/airspyone_host.git
+source: git+https://github.com/pothosware/SoapyBladeRF.git

--- a/soapymultisdr.lwr
+++ b/soapymultisdr.lwr
@@ -19,12 +19,8 @@
 
 category: hardware
 depends:
-- libusb
-description: Host side software for AirSpy dongles
+- soapysdr
+description: Soapy SDR module for multi-device support
 gitbranch: master
 inherit: cmake
-satisfy:
-  deb: airspy
-  port: airspy
-  pacman: airspy
-source: git+https://github.com/airspy/airspyone_host.git
+source: git+https://github.com/pothosware/SoapyMultiSDR.git

--- a/soapyremote.lwr
+++ b/soapyremote.lwr
@@ -19,12 +19,8 @@
 
 category: hardware
 depends:
-- libusb
-description: Host side software for AirSpy dongles
+- soapysdr
+description: Soapy SDR module for remote operation
 gitbranch: master
 inherit: cmake
-satisfy:
-  deb: airspy
-  port: airspy
-  pacman: airspy
-source: git+https://github.com/airspy/airspyone_host.git
+source: git+https://github.com/pothosware/SoapyRemote.git

--- a/soapyuhd.lwr
+++ b/soapyuhd.lwr
@@ -19,12 +19,10 @@
 
 category: hardware
 depends:
-- libusb
-description: Host side software for AirSpy dongles
+- soapysdr
+- uhd
+- boost
+description: Soapy SDR module for USRP hardware driver
 gitbranch: master
 inherit: cmake
-satisfy:
-  deb: airspy
-  port: airspy
-  pacman: airspy
-source: git+https://github.com/airspy/airspyone_host.git
+source: git+https://github.com/pothosware/SoapyUHD.git


### PR DESCRIPTION
This adds Soapy SDR modules for the following hardware:
* Airspy
* Airspy HF+
* BladeRF
* USRP (via UHD)

It also adds SoapyMultiSDR (for multi-device support) and SoapyRemote (for remote operation).

The Airspy HF+ driver was not present in gr-recipes, so I added it. I also updated the Airspy recipe to point to the new location as the GitHub repository has been renamed.

@mbr0wn 
