### PR TITLE
Add recipe for osmo-fl2k.

### DIFF
--- a/osmo-fl2k.lwr
+++ b/osmo-fl2k.lwr
@@ -1,0 +1,26 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: hardware
+depends:
+- libusb
+description: Turns FL2000-based USB 3.0 to VGA adapters into low cost DACs
+gitbranch: master
+inherit: cmake
+source: git+git://git.osmocom.org/osmo-fl2k.git


### PR DESCRIPTION
This PR adds a recipe for [osmo-fl2k](https://osmocom.org/projects/osmo-fl2k/wiki). Since it can be used with GNU Radio, I thought it would be useful to have it in PyBOMBS.