### PR TITLE
package fix for Ubuntu 18.04

### DIFF
--- a/ssl.lwr
+++ b/ssl.lwr
@@ -19,7 +19,7 @@
 
 category: baseline
 satisfy:
-  deb: libssl-dev
+  deb: libssl1.0-dev
   rpm: openssl-devel || libopenssl-devel
   pacman: openssl
   port: openssl


### PR DESCRIPTION
to fix libcrypto missing error