### PR TITLE
Fixing compilation issue on more recent systems

### DIFF
--- a/apache-thrift.lwr
+++ b/apache-thrift.lwr
@@ -37,7 +37,7 @@ depends:
 - ssl
 - pkg-config
 - twisted
-gitrev: 0.9.3
+gitrev: 0.10.0
 inherit: bootstrapautoconf
 source: git+https://github.com/apache/thrift.git
 satisfy:


### PR DESCRIPTION
See https://github.com/gnuradio/pybombs/issues/465
On recent Debian systems, Apache Thrift 0.9.3 does not compile, therefore bumping version to 0.10.0. (Most recent version 0.11.0 breaks gnuradio build).