### PR TITLE
Add gmp-devel rpm package

### DIFF
--- a/gmp.lwr
+++ b/gmp.lwr
@@ -21,6 +21,7 @@ category: baseline
 inherit: autoconf
 satisfy:
   deb: libgmp-dev
+  rpm: gmp-devel
   pacman: gmp
   port: gmp
   portage: dev-libs/gmp


### PR DESCRIPTION
Without it installation in a centos 7 container fails with 
```
$ pybombs prefix init -a default -R gnuradio-default ~/gnuradio/default

-- checking for module 'gmp'
--   package 'gmp' not found
-- Could NOT find GMP (missing:  GMPXX_LIBRARY GMP_INCLUDE_DIR) 
-- checking for module 'mpir >= 3.0'
--   package 'mpir >= 3.0' not found
-- Could NOT find MPIR (missing:  MPIRXX_LIBRARY MPIR_LIBRARY MPIR_INCLUDE_DIR) 
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:108 (message):
  Could NOT find MPLIB (missing: MPLIBXX_LIBRARY MPLIB_LIBRARY
  MPLIB_INCLUDE_DIR)
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:315 (_FPHSA_FAILURE_MESSAGE)
  cmake/Modules/FindMPLIB.cmake:26 (find_package_handle_standard_args)
  gnuradio-runtime/CMakeLists.txt:26 (find_package)


-- Configuring incomplete, errors occurred!
```
while actually gmp was installed by pybombs
```
$ pybombs inv
PyBOMBS.ConfigManager - INFO - Prefix Python version is: 2.7.5
PyBOMBS - INFO - PyBOMBS Version 2.3.3a0
Showing package state:
automake:           installed
gmp:                installed
libusb:             installed
uhd:                installed
gnuradio:           fetched
```