### PR TITLE
 Update talloc and pcsclite source URLs 

### DIFF
--- a/libtalloc-dev.lwr
+++ b/libtalloc-dev.lwr
@@ -26,4 +26,4 @@ satisfy:
   rpm: libtalloc-devel >= 2.0.1
   pacman: talloc >= 2.0.1
   portage: sys-libs/talloc >= 2.0.1
-source: git+git://anonscm.debian.org/pkg-samba/talloc.git
+source: git+https://salsa.debian.org/samba-team/talloc.git

--- a/pcsclite.lwr
+++ b/pcsclite.lwr
@@ -32,4 +32,4 @@ satisfy:
   rpm: pcsc-lite-devel >= 1.8.10
   pacman: pcsclite >= 1.8.10
   portage: sys-apps/pcsc-lite >= 1.8.10
-source: git+git://anonscm.debian.org/pcsclite/PCSC.git
+source: git+https://salsa.debian.org/debian/pcsc-lite.git


### PR DESCRIPTION
The alioth.debian.org service has been discontinued and replaced by salsa.debian.org