### PR TITLE
libudev: Install systemd-devel

### DIFF
--- a/libudev.lwr
+++ b/libudev.lwr
@@ -21,5 +21,5 @@ category: baseline
 depends: null
 satisfy:
   deb: libudev-dev
-  rpm: libgudev-devel || libudev-devel || libgudev1-devel
+  rpm: (libgudev-devel || libgudev1-devel) && (libudev-devel || systemd-devel)
   portage: virtual/libudev


### PR DESCRIPTION
On recent Fedora and Centos versions the libudev is provided by
systemd-devel package