### PR TITLE
pygraphviz: Remove the duplicated rpm entry

### DIFF
--- a/pygraphviz.lwr
+++ b/pygraphviz.lwr
@@ -22,7 +22,6 @@ category: baseline
 satisfy:
   deb: python-pygraphviz
   rpm: python-pygraphviz || python2-pygraphviz
-  rpm: python-pygraphviz
 satisfy@python3:
   deb: python3-pygraphviz
   rpm: python3-pygraphviz


### PR DESCRIPTION
PyBOMBS.recipes - WARNING - Recipe for `pygraphviz' is invalid.