### PR TITLE
Make the GNU Radio recipe build maint-3.7 instead of master

### DIFF
--- a/gnuradio.lwr
+++ b/gnuradio.lwr
@@ -49,7 +49,7 @@ satisfy:
   portage: net-wireless/gnuradio
   pkgconfig: gnuradio-runtime
 source: git+https://github.com/gnuradio/gnuradio.git
-gitbranch: master
+gitbranch: maint-3.7
 gitargs: --recursive
 vars: # We explicitly enable some subcomponents to make sure the build fails if they're not working:
   config_opt: " -DENABLE_DOXYGEN=$builddocs -DENABLE_GR_AUDIO=ON -DENABLE_GR_BLOCKS=ON -DENABLE_GR_DIGITAL=ON -DENABLE_GR_FEC=ON -DENABLE_GR_FFT=ON -DENABLE_GR_FILTER=ON -DENABLE_GR_QTGUI=ON -DENABLE_GR_UHD=ON -DENABLE_PYTHON=ON -DENABLE_VOLK=ON -DENABLE_GRC=ON "


### PR DESCRIPTION
In light of the fact that the recipe doesn't contain next dependencies, and 3.7.XX has reached a level of usefulness that makes it feasible for most people that use pybombs, we should be migrating away from master to save us from major headache.

We should also be having a GNU Radio development version recipe.