### PR TITLE
Created recipe for 3.8 (gnuradio master)

### DIFF
--- a/gnuradio38.lwr
+++ b/gnuradio38.lwr
@@ -1,0 +1,61 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+depends:
+- qt5
+- boost
+- fftw
+- cppunit
+- swig
+- gsl
+- gmp
+- uhd
+- alsa
+- cheetah
+- wxpython
+- numpy
+- lxml
+- pygtk
+- pycairo
+- pyqt5
+- qwt5
+- pyqwt5
+- apache-thrift
+- liblog4cpp
+- zeromq
+- python-zmq
+description: Free and open source toolkit for software defined radio
+category: common
+satisfy:
+  deb: gnuradio-dev
+  rpm: gnuradio-devel
+  pacman: gnuradio
+  port: gnuradio
+  portage: net-wireless/gnuradio
+  pkgconfig: gnuradio-runtime
+source: git+https://github.com/gnuradio/gnuradio.git
+gitbranch: master
+gitargs: --recursive
+vars: # We explicitly enable some subcomponents to make sure the build fails if they're not working:
+  config_opt: " -DENABLE_DOXYGEN=$builddocs -DENABLE_GR_AUDIO=ON -DENABLE_GR_BLOCKS=ON -DENABLE_GR_DIGITAL=ON -DENABLE_GR_FEC=ON -DENABLE_GR_FFT=ON -DENABLE_GR_FILTER=ON -DENABLE_GR_QTGUI=ON -DENABLE_GR_UHD=ON -DENABLE_PYTHON=ON -DENABLE_VOLK=ON -DENABLE_GRC=ON "
+inherit: cmake
+configure_static: cmake .. -DCMAKE_BUILD_TYPE=$cmakebuildtype -DCMAKE_INSTALL_PREFIX=$prefix -DENABLE_STATIC_LIBS=True $config_opt
+install: |
+    make install
+    make install


### PR DESCRIPTION
It's the same as gnuradio.lwr except it tracks master and I had to add qt5 and pyqt5.  This recipe will only work once my pybombs PR is accepted which adds the python3.5/dist-packages to setup_env.sh (until then just manually add it to your setup_env.sh)