### PR TITLE
fix Error fetching recipe `g'

### DIFF
--- a/gr-mapper.lwr
+++ b/gr-mapper.lwr
@@ -18,7 +18,8 @@
 #
 
 category: common
-depends: gnuradio
+depends: 
+- gnuradio
 description: Symbol to Bit Mapping and Demapping Blocks for GNU Radio
 gitbranch: master
 inherit: cmake


### PR DESCRIPTION
Trying to run 
`pybombs install gr-mapper` 
fails due to a bad recipe file. The proposed change here fixes the issue and allows gr-mapper to be installed successfully.