### PR TITLE
fix build error.

### DIFF
--- a/gr-ldpc.lwr
+++ b/gr-ldpc.lwr
@@ -18,7 +18,8 @@
 #
 
 category: common
-depends: gnuradio
+depends:
+  - gnuradio
 source: git+https://github.com/manuts/gr-ldpc.git
 gitbranch: master
 inherit: cmake


### PR DESCRIPTION
```
PyBOMBS.get_recipe - ERROR - Error fetching recipe `g':
Package g has no recipe file!
```