### PR TITLE
update branches of foo, 802.11, rds

### DIFF
--- a/gr-foo.lwr
+++ b/gr-foo.lwr
@@ -21,7 +21,7 @@ category: common
 depends:
 - gnuradio
 description: Some additional blocks like packetpad that are required by, e.g., gr-ieee80211
-gitbranch: master
+gitbranch: maint-3.7
 inherit: cmake
 satisfy:
   port: gr-foo

--- a/gr-ieee-80211.lwr
+++ b/gr-ieee-80211.lwr
@@ -21,11 +21,10 @@ category: common
 depends:
 - gnuradio
 - uhd
-- libitpp
 - liblog4cpp
 - gr-foo
 description: IEEE 802.11 a/g/p Transceiver
-gitbranch: master
+gitbranch: maint-3.7
 inherit: cmake
 satisfy:
   port: gr-ieee802-11

--- a/gr-rds.lwr
+++ b/gr-rds.lwr
@@ -21,7 +21,7 @@ category: common
 depends:
 - gnuradio
 description: FM RDS/TMC Transceiver
-gitbranch: master
+gitbranch: maint-3.7
 inherit: cmake
 satisfy:
   port: gr-rds


### PR DESCRIPTION
I ported my modules and switched over to the proposed dev scheme for 3.8, i.e., the legacy branch was renamed to *maint-3.7*.