### PR TITLE
liblog4cpp: update source package version, allowing C++17 usage

### DIFF
--- a/liblog4cpp.lwr
+++ b/liblog4cpp.lwr
@@ -31,6 +31,6 @@ satisfy:
   portage: dev-libs/log4cpp
   pacman: log4cpp
   pkgconfig: log4cpp
-source: wget+http://prdownloads.sourceforge.net/log4cpp/log4cpp-1.1.1.tar.gz
+source: wget+http://prdownloads.sourceforge.net/log4cpp/log4cpp-1.1.3.tar.gz
 vars:
   config_opt: --with-pthreads


### PR DESCRIPTION
If log4cpp was build from source, version 1.1.1 contained illegal instructions in C++17, which affect all other softwares linking to it. Upstream version 1.1.3 solves this issue.