### PR TITLE
Update recipes to GNU Radio 3.8 release

### DIFF
--- a/gnuradio38.lwr
+++ b/gnuradio38.lwr
@@ -25,15 +25,18 @@ depends:
 - gmp
 - uhd
 - alsa
+- qt5
+- qwt6
 - numpy
 - lxml
 - pygtk
 - pycairo
 - pyqt5
-- qwt5
 - liblog4cpp
 - zeromq
 - python-zmq
+- python-click-plugins
+- python-pyqtgraph
 - mako
 description: Free and open source toolkit for software defined radio
 category: common
@@ -45,7 +48,7 @@ satisfy:
   portage: net-wireless/gnuradio
   pkgconfig: gnuradio-runtime
 source: git+https://github.com/gnuradio/gnuradio.git
-gitbranch: master
+gitbranch: maint-3.8
 gitargs: --recursive
 vars: # We explicitly enable some subcomponents to make sure the build fails if they're not working:
   config_opt: " -DENABLE_DOXYGEN=$builddocs -DENABLE_GR_AUDIO=ON -DENABLE_GR_BLOCKS=ON -DENABLE_GR_DIGITAL=ON -DENABLE_GR_FEC=ON -DENABLE_GR_FFT=ON -DENABLE_GR_FILTER=ON -DENABLE_GR_QTGUI=ON -DENABLE_GR_UHD=ON -DENABLE_PYTHON=ON -DENABLE_VOLK=ON -DENABLE_GRC=ON "

--- a/python-click-plugins.lwr
+++ b/python-click-plugins.lwr
@@ -18,9 +18,13 @@
 #
 
 category: baseline
+depends:
+- python
+description: A module for writing portable GUI applications with Python using Tk
 satisfy:
-  deb: libqt5opengl5-dev && libqt5svg5-dev && qt5-default
-  rpm: (qt5-qtbase-devel && qt5-qtsvg-devel) || (devel_qt5 && libqt5-qtsvg-devel)
-  pacman: qt5-base
-  port: qt5 && qt5-qtbase
-  portage: dev-qt/qtgui
+  deb: python-click-plugins
+  rpm: python-click-plugins || python2-click-plugins
+  port: py27-click-plugins
+satisfy@python3:
+  deb: python3-click-plugins
+  rpm: python3-click-plugins

--- a/python-pyqtgraph.lwr
+++ b/python-pyqtgraph.lwr
@@ -18,9 +18,15 @@
 #
 
 category: baseline
+depends:
+- python
+- numpy
+description: Scientific Graphics and GUI Library for Python
 satisfy:
-  deb: libqt5opengl5-dev && libqt5svg5-dev && qt5-default
-  rpm: (qt5-qtbase-devel && qt5-qtsvg-devel) || (devel_qt5 && libqt5-qtsvg-devel)
-  pacman: qt5-base
-  port: qt5 && qt5-qtbase
-  portage: dev-qt/qtgui
+  deb: python-pyqtgraph
+  rpm: python-pyqtgraph || python2-pyqtgraph
+  port: py27-pyqtgraph
+  python: pyqtgraph
+satisfy@python3:
+  deb: python3-pyqtgraph
+  rpm: python3-pyqtgraph

--- a/qwt6.lwr
+++ b/qwt6.lwr
@@ -28,8 +28,8 @@ depends:
 inherit: autoconf
 make: "make    \n"
 satisfy:
-  deb: libqwt-dev >= 6.1
-  rpm: qwt-devel >= 6.1
+  deb: libqwt-qt5-dev && libqwt-dev >= 6.1
+  rpm: qwt-qt5-devel && qwt-devel >= 6.1
   port: qwt61
   pacman: qwt >= 6.1
   portage: x11-libs/qwt >= 6.1


### PR DESCRIPTION
- Change gnuradio38 branch to maint-3.8
- Add dependency python-click-plugins, fixes #153
- Add dependency python-pyqtgraph, fixes #154

I could successfully install GNU Radio 3.8 with these recipes, however I might have missed dependencies that were already installed on my system.