### PR TITLE
gr-foo, gr-iio defaulting to maint-3.8 branches

### DIFF
--- a/gr-foo.lwr
+++ b/gr-foo.lwr
@@ -21,7 +21,7 @@ category: common
 depends:
 - gnuradio
 description: Some additional blocks like packetpad that are required by, e.g., gr-ieee80211
-gitbranch: maint-3.7
+gitbranch: maint-3.8
 inherit: cmake
 satisfy:
   port: gr-foo

--- a/gr-ieee-80211.lwr
+++ b/gr-ieee-80211.lwr
@@ -24,7 +24,7 @@ depends:
 - liblog4cpp
 - gr-foo
 description: IEEE 802.11 a/g/p Transceiver
-gitbranch: maint-3.7
+gitbranch: maint-3.8
 inherit: cmake
 satisfy:
   port: gr-ieee802-11

--- a/gr-iio.lwr
+++ b/gr-iio.lwr
@@ -25,7 +25,7 @@ depends:
 - flex
 - bison
 description: GNU Radio IIO Blocks
-gitrev: tags/v0.3
+gitbranch: upgrade-3.8
 inherit: cmake
 # Let's always build this from source, not binaries
 source: git+https://github.com/analogdevicesinc/gr-iio.git


### PR DESCRIPTION
I was just moving from gr 3.7 to 3.8 and ran into some error messages as some recipes default to git branches for 3.7, but the gnuradio recipe defaults to 3.8