### PR TITLE
qwt6: Install either libqwt-qt5-dev or libqwt-dev

### DIFF
--- a/qwt6.lwr
+++ b/qwt6.lwr
@@ -28,9 +28,9 @@ depends:
 inherit: autoconf
 make: "make    \n"
 satisfy:
-  deb: libqwt-qt5-dev && libqwt-dev >= 6.1
-  rpm: qwt-qt5-devel && qwt-devel >= 6.1
+  deb: libqwt-qt5-dev || libqwt-dev >= 6.1
+  rpm: qwt-qt5-devel || qwt-devel >= 6.1
   port: qwt61
   pacman: qwt >= 6.1
   portage: x11-libs/qwt >= 6.1
-source: wget+http://prdownloads.sourceforge.net/qwt/qwt-6.1.0.tar.bz2
+source: wget+http://prdownloads.sourceforge.net/qwt/qwt-6.1.4.tar.bz2


### PR DESCRIPTION
In Debian testing the libqwt-dev package has been removed so replace &&
with ||. Fix the rpms as well.

Update the source URL to version 6.1.4 to fix the following errors:

qwt_transform.h:110:5: error: ‘QT_STATIC_CONST’ does not name a type
110 | QT_STATIC_CONST double LogMin;
| ^~~~~~~~~~~~~~~
qwt_transform.h:111:5: error: ‘QT_STATIC_CONST’ does not name a type
111 | QT_STATIC_CONST double LogMax;
| ^~~~~~~~~~~~~~~

Fixes #161