### PR TITLE
libosmocore: Build without SCTP support

### DIFF
--- a/libosmocore.lwr
+++ b/libosmocore.lwr
@@ -33,3 +33,5 @@ description: A library with generic ulitity functions developed by Osmocom proje
 gitbranch: master
 inherit: autoconf
 source: git+https://git.osmocom.org/libosmocore
+vars:
+  config_opt: ' --disable-libsctp '


### PR DESCRIPTION
In [libosmocore 1.3.0 (ea2afb21d)](https://github.com/osmocom/libosmocore/blob/1.3.0/configure.ac#L176-L190) the SCTP support was added and enabled
by default. The build fails when sctp library is not found.

Support for SCTP on non Linux operating systems is problematic and SCTP
is not needed by most SDR applications so buid without it by adding
--disable-libsctp to configure options.