### PR TITLE
Update gr-limesdr.lwr

### DIFF
--- a/gr-limesdr.lwr
+++ b/gr-limesdr.lwr
@@ -22,6 +22,6 @@ depends:
 - gnuradio
 - limesuite
 description: GNU Radio source and sink blocks for LimeSDR hardware
-gitbranch: master
+gitbranch: gr-3.8
 inherit: cmake
 source: git+https://github.com/myriadrf/gr-limesdr


### PR DESCRIPTION
Instead of pointing to the master branch (currently for gnuradio 3.7) point to the gr-3.8 branch. Since the default recipe for gnuradio is now pointing at the maint-3.8 branch.
https://github.com/myriadrf/gr-limesdr/tree/gr-3.8 has 79 commits
https://github.com/myriadrf/gr-limesdr/tree/master only has 62 commits