### PR TITLE
volk: Add libvolk recipe

### DIFF
--- a/libvolk.lwr
+++ b/libvolk.lwr
@@ -1,0 +1,28 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends:
+- mako
+description: Vector Optimized Library of Kernels
+satisfy:
+  deb: libvolk-dev
+gitbranch: master
+inherit: cmake
+source: git+https://github.com/gnuradio/volk.git

--- a/libvolk.lwr
+++ b/libvolk.lwr
@@ -22,7 +22,7 @@ depends:
 - mako
 description: Vector Optimized Library of Kernels
 satisfy:
-  deb: libvolk-dev
+  deb: libvolk2-dev
 gitbranch: master
 inherit: cmake
 source: git+https://github.com/gnuradio/volk.git


### PR DESCRIPTION
In order to remove VOLK as a GR submodule, a PyBOMBS recipe to build it and make GR depend on it, is required. This PR is supposed to support that goal.