### PR TITLE
dep: Add libvolk dependency to gnuradio

### DIFF
--- a/gnuradio.lwr
+++ b/gnuradio.lwr
@@ -32,6 +32,7 @@ depends:
 - pygtk
 - pycairo
 - pyqt5
+- libvolk
 - liblog4cpp
 - zeromq
 - python-zmq


### PR DESCRIPTION
Fix #181 