### PR TITLE
package: install correct packages

### DIFF
--- a/pygtk.lwr
+++ b/pygtk.lwr
@@ -34,4 +34,6 @@ satisfy:
   port: py27-pygtk >= 2.17
   portage: dev-python/pygtk >= 2.17
   pip: PyGTK >= 2.17
+satisfy@python3:
+  deb: python3-gi
 source: wget+http://ftp.gnome.org/pub/GNOME/sources/pygtk/2.24/pygtk-2.24.0.tar.bz2


### PR DESCRIPTION
This commit changes the packages that are installed for python3.
Otherwise a system without Python2 will start to compile e.g. pango from source.
Still, the installed package would be incorrect.

Fix #182 

I hope this is the correct package to install. Or should this just be an empty dependency in case of Python3? It seems like this dependency is unnecessary.