### PR TITLE
gqrx: Remove dependency on qt4

### DIFF
--- a/gqrx.lwr
+++ b/gqrx.lwr
@@ -22,7 +22,6 @@ depends:
 - gnuradio
 - gr-osmosdr
 - pulseaudio
-- qt4
 - qt5
 description: A SDR receiver using GNU Radio SDR framework and Qt graphical toolkit
 gitbranch: master


### PR DESCRIPTION
Gqrx fails to build on Ubuntu 20.04 because the recipe lists a dependency on Qt4. Gqrx in fact depends on Qt5, which already appears in the dependency list. Therefore qt4 can simply be removed.