### PR TITLE
gnuradio: Remove dependency on PyGTK

### DIFF
--- a/gnuradio.lwr
+++ b/gnuradio.lwr
@@ -29,7 +29,6 @@ depends:
 - qwt6
 - numpy
 - lxml
-- pygtk
 - pycairo
 - pyqt5
 - liblog4cpp

--- a/gnuradio38.lwr
+++ b/gnuradio38.lwr
@@ -29,7 +29,6 @@ depends:
 - qwt6
 - numpy
 - lxml
-- pygtk
 - pycairo
 - pyqt5
 - liblog4cpp


### PR DESCRIPTION
GNU Radio 3.8 fails to install on Ubuntu 20.04 because the recipes specify a dependency on PyGTK. The PyGTK dependency was replaced with PyGObject in GNU Radio 3.8 (https://github.com/gnuradio/gnuradio/commit/395bd4415cc92217886d0f2a4f026a6070e1748b) so pygtk should be removed from the GNU Radio 3.8 recipes.