### PR TITLE
Add a prefix recipe for GNU Radio master

### DIFF
--- a/gnuradio-master.lwr
+++ b/gnuradio-master.lwr
@@ -1,0 +1,34 @@
+#
+# This file is part of GNU Radio
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+inherit: prefix
+depends:
+        - gnuradio
+config:
+  packages:
+    apache-thrift:
+      optional: True
+    wxpython:
+      optional: True
+    doxygen:
+      optional: True
+    gnuradio:
+      gitbranch: master
+    gqrx:
+      forcebuild: True


### PR DESCRIPTION
Currently there are two recipes for use with the `pybombs prefix` command: 

* `gnuradio-stable` builds maint-3.7
* `gnuradio-default` builds maint-3.8

It would be convenient to have one to build master, so I've added that here. The `gnuradio-master` recipe is a copy of `gnuradio-default` with the following addition:

```
    gnuradio:
      gitbranch: master
```