### PR TITLE
gr-osmosdr: add missing dependencies

### DIFF
--- a/gr-osmosdr.lwr
+++ b/gr-osmosdr.lwr
@@ -27,9 +27,13 @@ depends:
 - gr-iqbal
 - bladeRF
 - airspy
+- airspyhf
 - soapysdr
+- gr-fcdproplus
 description: Interface API independent of the underlying radio hardware
 gitbranch: master
 inherit: cmake
 # Let's always build this from source, not binaries
 source: git+https://git.osmocom.org/gr-osmosdr
+vars:
+  config_opt: ' -DENABLE_NONFREE=TRUE '


### PR DESCRIPTION
The gr-osmosdr recipe is missing some of the optional dependencies needed to build modules for its supported SDR boards. As a result, support for Airspy HF and FUNcube Dongle hardware is not built. This change adds the missing dependencies.

In addition, SDRplay support is not built, even if the required library is present, because gr-osmosdr requires the ENABLE_NONFREE config option to be set. I've added it to config_opt.