### PR TITLE
Add gr-gmuground.lwr

### DIFF
--- a/gr-gmuground.lwr
+++ b/gr-gmuground.lwr
@@ -1,0 +1,26 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends:
+- gnuradio
+description: A collection of OOT modules for developing an amateur satellite communications ground station. 
+gitbranch: maint-3.8
+inherit: cmake
+source: git+https://github.com/wbarnha/gr-gmuground.git


### PR DESCRIPTION
Moved from gr-etcetera.

I'd like to add this to gr-recipes so that gr-gmuground can appear on cgran.org and make future amateur satellite communications simpler for some people. However, there's a laundry list of dependencies I have developed my repo around and I'm not sure if I should leave the dependencies in the .lwr as is and instruct users to install from source. There's also some blacklisted dependencies, such as gr-fosphor, and I'm not sure if that would be incompatible with Pybombs or not.