### PR TITLE
Use maint-3.8 branches when building with GNU Radio 3.8

### DIFF
--- a/gnuradio-default.lwr
+++ b/gnuradio-default.lwr
@@ -30,5 +30,9 @@ config:
       optional: True
     gqrx:
       forcebuild: True
-
-
+    gr-display:
+      gitbranch: v3.8
+    gr-filerepeater:
+      gitbranch: maint-3.8
+    gr-lfast:
+      gitbranch: maint-3.8


### PR DESCRIPTION
Some projects are now targeting GNU Radio 3.9 on their master branches, so it's necessary to check out maint-3.8 (or similar) to build with GNU Radio 3.8. Here I've updated the gnuradio-default (3.8) recipe to override the git branch for some recipes that need this.