### PR TITLE
Update gr-satellites recipe dependencies

### DIFF
--- a/gr-satellites.lwr
+++ b/gr-satellites.lwr
@@ -20,9 +20,9 @@
 category: common
 depends:
 - gnuradio
-- libfec
+- python-requests
 - pyconstruct
-description: GNU Radio decoders for several Amateur satellites
+description: A collection of decoders for Amateur satellites
 gitbranch: master
 inherit: cmake
 source: git+https://github.com/daniestevez/gr-satellites


### PR DESCRIPTION
gr-satellites does not require libfec since v3.3.0 and it
requires python-construct since a while ago.

I have also taken the occasion to update the description.