### PR TITLE
Adding missing dependency (see gnuradio/gr-recipes#195) for airspy.lwr

### DIFF
--- a/airspy.lwr
+++ b/airspy.lwr
@@ -20,6 +20,7 @@
 category: hardware
 depends:
 - libusb
+- pkg-config
 description: Host side software for AirSpy dongles
 gitbranch: master
 inherit: cmake


### PR DESCRIPTION
This fixes a build fail on Ubuntu 20.04 (at least) -- fixes gnuradio/gr-recipes#195.