### PR TITLE
Fix malformed depends

### DIFF
--- a/curl.lwr
+++ b/curl.lwr
@@ -18,7 +18,6 @@
 #
 
 category: baseline
-depends: null
 satisfy:
   deb: curl || libcurl3
   rpm: curl

--- a/gcc.lwr
+++ b/gcc.lwr
@@ -18,7 +18,6 @@
 #
 
 category: baseline
-depends: null
 satisfy:
   deb: gcc && g++
   rpm: gcc-c++

--- a/gr-mapper.lwr
+++ b/gr-mapper.lwr
@@ -18,7 +18,7 @@
 #
 
 category: common
-depends: 
+depends:
 - gnuradio
 description: Symbol to Bit Mapping and Demapping Blocks for GNU Radio
 gitbranch: master

--- a/libfec.lwr
+++ b/libfec.lwr
@@ -18,7 +18,6 @@
 #
 
 category: common
-depends:
 description: Phil Karn's libfec
 gitbranch: master
 inherit: cmake

--- a/libjpeg.lwr
+++ b/libjpeg.lwr
@@ -18,7 +18,6 @@
 #
 
 category: baseline
-depends: null
 satisfy:
   deb: libjpeg-turbo8-dev || libjpeg62-dev || libjpeg62-turbo-dev
   rpm: libjpeg-devel || libjpeg-turbo-devel || libjpeg8-devel || libjpeg62-devel

--- a/libtiff.lwr
+++ b/libtiff.lwr
@@ -18,7 +18,6 @@
 #
 
 category: baseline
-depends: null
 satisfy:
   deb: libtiff5-dev || libtiff4-dev
   rpm: libtiff-devel

--- a/libudev.lwr
+++ b/libudev.lwr
@@ -18,7 +18,6 @@
 #
 
 category: baseline
-depends: null
 satisfy:
   deb: libudev-dev
   rpm: (libgudev-devel || libgudev1-devel) && (libudev-devel || systemd-devel)

--- a/mbelib.lwr
+++ b/mbelib.lwr
@@ -18,7 +18,6 @@
 #
 
 category: baseline
-depends: null
 gitbranch: master
 inherit: cmake
 source: git+https://github.com/szechyjs/mbelib.git

--- a/pygraphviz.lwr
+++ b/pygraphviz.lwr
@@ -17,7 +17,6 @@
 # Boston, MA 02110-1301, USA.
 #
 
-depends: null
 category: baseline
 satisfy:
   deb: python-pygraphviz

--- a/sqlite.lwr
+++ b/sqlite.lwr
@@ -18,7 +18,6 @@
 #
 
 category: baseline
-depends: null
 satisfy:
   deb: libsqlite3-dev
   portage: dev-db/sqlite

--- a/subversion.lwr
+++ b/subversion.lwr
@@ -18,7 +18,6 @@
 #
 
 category: baseline
-depends: null
 satisfy:
   deb: subversion
   rpm: subversion

--- a/x11.lwr
+++ b/x11.lwr
@@ -18,7 +18,6 @@
 #
 
 category: baseline
-depends: null
 satisfy:
   deb: (libx11-dev || libX11-dev) && libxrender-dev
   rpm: libX11-devel && libXrender-devel && libXext-devel


### PR DESCRIPTION
I ran `pybombs lint` against everything in gr-recipes, and it complained loudly about some broken `depends`:

```
[VERY BAD] Dependencies is not a list: None
```

It looks like recipes that don't have any dependencies should not have a `depends` property, so I've removed them here.