### PR TITLE
volk: Update VOLK recipe with git recursive

### DIFF
--- a/libvolk.lwr
+++ b/libvolk.lwr
@@ -24,5 +24,6 @@ description: Vector Optimized Library of Kernels
 satisfy:
   deb: libvolk2-dev
 gitbranch: master
+gitargs: --recursive
 inherit: cmake
 source: git+https://github.com/gnuradio/volk.git


### PR DESCRIPTION
VOLK master relies on cpu_features now. The recipe asks to clone VOLK
master. Thus, we need to clone VOLK recursively now. This shouldn't
break things for older version because it the `--recursive` flags would
just fall through.