### PR TITLE
Fix building packages on gnuradio 3.7 and 3.8

### DIFF
--- a/gnuradio-default.lwr
+++ b/gnuradio-default.lwr
@@ -32,7 +32,13 @@ config:
       forcebuild: True
     gr-display:
       gitbranch: v3.8
+    gr-fosphor:
+      gitbranch: gr3.8
     gr-filerepeater:
       gitbranch: maint-3.8
+    gr-iqbal:
+      gitbranch: gr3.8
     gr-lfast:
       gitbranch: maint-3.8
+    gr-osmosdr:
+      gitbranch: gr3.8

--- a/gnuradio-stable.lwr
+++ b/gnuradio-stable.lwr
@@ -34,4 +34,9 @@ config:
       gitbranch: UHD-3.15.LTS
     gqrx:
       forcebuild: True
-
+    gr-iqbal:
+      gitbranch: gr3.7
+    gr-osmosdr:
+      gitbranch: gr3.7
+    gr-fosphor:
+      gitbranch: gr3.7

--- a/pyyaml.lwr
+++ b/pyyaml.lwr
@@ -18,7 +18,6 @@
 #
 
 category: baseline
-inherit: autoconf
 depends:
 - python
 satisfy:


### PR DESCRIPTION
Fixes https://github.com/gnuradio/gr-recipes/issues/246, in which gr-iqbal will not build on gnuradio 3.8, and a similar bug in gr-osmosdr. I am not totally sure, but I think this also fixes https://github.com/gnuradio/gr-recipes/issues/191.

A subset of these changes is also made in https://github.com/gnuradio/gr-recipes/pull/245, but I do not know if that PR is going to be merged because it also changes the mirrors for Osmocom repos.