### PR TITLE
Fix Osmocom packages on GNURadio 3.8

### DIFF
--- a/gnuradio-default.lwr
+++ b/gnuradio-default.lwr
@@ -32,7 +32,15 @@ config:
       forcebuild: True
     gr-display:
       gitbranch: v3.8
+    gr-fosphor:
+      gitbranch: gr3.8
     gr-filerepeater:
       gitbranch: maint-3.8
+    gr-gsm:
+      gitbranch: porting_to_gr38
+    gr-iqbal:
+      gitbranch: gr3.8
     gr-lfast:
       gitbranch: maint-3.8
+    gr-osmosdr:
+      gitbranch: gr3.8

--- a/libmnl.lwr
+++ b/libmnl.lwr
@@ -17,15 +17,7 @@
 # Boston, MA 02110-1301, USA.
 #
 
-category: common
-depends:
-- gnuradio
-- glfw3
-- freetype
-- opencl
-description: RTSA-like spectrum visualization using OpenCL and OpenGL
-gitbranch: master
-inherit: cmake
+category: baseline
 satisfy:
-  port: gr-fosphor
-source: git+https://git.osmocom.org/gr-fosphor
+  deb: libmnl-dev
+  rpm: libmnl-devel

--- a/libosmocore.lwr
+++ b/libosmocore.lwr
@@ -29,6 +29,7 @@ depends:
 - pcsclite
 - libtalloc-dev
 - gnutls
+- libmnl
 description: A library with generic ulitity functions developed by Osmocom project
 gitbranch: master
 inherit: autoconf

--- a/opencl.lwr
+++ b/opencl.lwr
@@ -17,15 +17,7 @@
 # Boston, MA 02110-1301, USA.
 #
 
-category: common
-depends:
-- gnuradio
-- glfw3
-- freetype
-- opencl
-description: RTSA-like spectrum visualization using OpenCL and OpenGL
-gitbranch: master
-inherit: cmake
+category: baseline
 satisfy:
-  port: gr-fosphor
-source: git+https://git.osmocom.org/gr-fosphor
+  deb: opencl-headers && ocl-icd-opencl-dev
+  rpm: opencl-headers && ocl-icd-devel


### PR DESCRIPTION
This fixes gr-iqbal, gr-osmosdr, gr-fosphor, and gr-gsm on GNURadio 3.8 by pinning them to the appropriate git branch for 3.8, and by adding some missing dependencies. This fixes https://github.com/gnuradio/gr-recipes/issues/246.