### PR TITLE
volk: Update branch name

### DIFF
--- a/libvolk.lwr
+++ b/libvolk.lwr
@@ -23,7 +23,7 @@ depends:
 description: Vector Optimized Library of Kernels
 satisfy:
   deb: libvolk2-dev
-gitbranch: master
+gitbranch: main
 gitargs: --recursive
 inherit: cmake
 source: git+https://github.com/gnuradio/volk.git


### PR DESCRIPTION
Fixes https://github.com/gnuradio/gr-recipes/issues/252.

VOLK has renamed its master branch to main (https://github.com/gnuradio/volk/issues/461) so its recipe needs to be updated accordingly.

/cc @jdemel