### PR TITLE
libvolk: use "main" branch

### DIFF
--- a/libvolk.lwr
+++ b/libvolk.lwr
@@ -23,7 +23,7 @@ depends:
 description: Vector Optimized Library of Kernels
 satisfy:
   deb: libvolk2-dev
-gitbranch: master
+gitbranch: main
 gitargs: --recursive
 inherit: cmake
 source: git+https://github.com/gnuradio/volk.git


### PR DESCRIPTION
The "master" branch is frozen, default is now "main".

Signed-off-by: Jeff Long <willcode4@gmail.com>