### PR TITLE
Debian qt5 recipe

### DIFF
--- a/qt5.lwr
+++ b/qt5.lwr
@@ -19,7 +19,7 @@
 
 category: baseline
 satisfy:
-  deb: libqt5opengl5-dev && libqt5svg5-dev && qt5-default
+  deb: libqt5opengl5-dev && libqt5svg5-dev && (qt5-default || qtbase5-dev)
   rpm: (qt5-qtbase-devel && qt5-qtsvg-devel) || (devel_qt5 && libqt5-qtsvg-devel)
   pacman: qt5-base
   port: qt5 && qt5-qtbase


### PR DESCRIPTION
PR adds an alternative package for qt5-default for Debian Buster.  Pybombs would fail to install the original package.