### PR TITLE
Update defaults

### DIFF
--- a/gnuradio-default.lwr
+++ b/gnuradio-default.lwr
@@ -19,28 +19,14 @@
 
 inherit: prefix
 depends:
-        - gnuradio
+        - gnuradio39
 config:
   packages:
     apache-thrift:
-      optional: True
-    wxpython:
       optional: True
     doxygen:
       optional: True
     gqrx:
       forcebuild: True
-    gr-display:
-      gitbranch: v3.8
-    gr-fosphor:
-      gitbranch: gr3.8
-    gr-filerepeater:
-      gitbranch: maint-3.8
-    gr-gsm:
-      gitbranch: porting_to_gr38
-    gr-iqbal:
-      gitbranch: gr3.8
-    gr-lfast:
-      gitbranch: maint-3.8
-    gr-osmosdr:
-      gitbranch: gr3.8
+    uhd:
+      gitbranch: UHD-4.0

--- a/gnuradio-master.lwr
+++ b/gnuradio-master.lwr
@@ -17,18 +17,41 @@
 # Boston, MA 02110-1301, USA.
 #
 
-inherit: prefix
 depends:
-        - gnuradio
-config:
-  packages:
-    apache-thrift:
-      optional: True
-    wxpython:
-      optional: True
-    doxygen:
-      optional: True
-    gnuradio:
-      gitbranch: master
-    gqrx:
-      forcebuild: True
+- boost
+- fftw
+- gsl
+- gmp
+- soapysdr
+- uhd
+- alsa
+- qt5
+- qwt6
+- numpy
+- lxml
+- pycairo
+- pyqt5
+- libvolk
+- liblog4cpp
+- zeromq
+- python-zmq
+- python-click-plugins
+- python-pyqtgraph
+- pyyaml
+- pygobject
+- gobject-introspection
+- gtk3
+- mako
+- pybind11
+- doxygen
+description: Free and open source toolkit for software defined radio
+category: common
+source: git+https://github.com/gnuradio/gnuradio.git
+gitbranch: master
+vars: # We explicitly enable some subcomponents to make sure the build fails if they're not working:
+  config_opt: " -DENABLE_DOXYGEN=$builddocs -DENABLE_GR_AUDIO=ON -DENABLE_GR_BLOCKS=ON -DENABLE_GR_CHANNELS=ON -DENABLE_GR_DIGITAL=ON -DENABLE_GR_FEC=ON -DENABLE_GR_FFT=ON -DENABLE_GR_FILTER=ON -DENABLE_GR_QTGUI=ON -DENABLE_GR_UHD=ON -DENABLE_GR_SOAPY=ON -DENABLE_PYTHON=ON -DENABLE_GRC=ON "
+inherit: cmake
+configure_static: cmake .. -DCMAKE_BUILD_TYPE=$cmakebuildtype -DCMAKE_INSTALL_PREFIX=$prefix -DENABLE_STATIC_LIBS=True $config_opt
+install: |
+    make install
+    make install

--- a/gnuradio-stable.lwr
+++ b/gnuradio-stable.lwr
@@ -19,18 +19,14 @@
 
 inherit: prefix
 depends:
-        - gnuradio
+        - gnuradio39
 config:
   packages:
     apache-thrift:
       optional: True
-    wxpython:
-      optional: True
     doxygen:
       optional: True
-    gnuradio:
-      gitbranch: maint-3.7
-    uhd:
-      gitbranch: UHD-3.15.LTS
     gqrx:
       forcebuild: True
+    uhd:
+      gitbranch: UHD-4.0

--- a/gnuradio.lwr
+++ b/gnuradio.lwr
@@ -20,9 +20,9 @@
 depends:
 - boost
 - fftw
-- swig
 - gsl
 - gmp
+- soapysdr
 - uhd
 - alsa
 - qt5
@@ -42,21 +42,14 @@ depends:
 - gobject-introspection
 - gtk3
 - mako
+- pybind11
 - doxygen
 description: Free and open source toolkit for software defined radio
 category: common
-satisfy:
-  deb: gnuradio-dev
-  rpm: gnuradio-devel
-  pacman: gnuradio
-  port: gnuradio
-  portage: net-wireless/gnuradio
-  pkgconfig: gnuradio-runtime
 source: git+https://github.com/gnuradio/gnuradio.git
-gitbranch: maint-3.8
-gitargs: --recursive
+gitbranch: maint-3.9
 vars: # We explicitly enable some subcomponents to make sure the build fails if they're not working:
-  config_opt: " -DENABLE_DOXYGEN=$builddocs -DENABLE_GR_AUDIO=ON -DENABLE_GR_BLOCKS=ON -DENABLE_GR_DIGITAL=ON -DENABLE_GR_FEC=ON -DENABLE_GR_FFT=ON -DENABLE_GR_FILTER=ON -DENABLE_GR_QTGUI=ON -DENABLE_GR_UHD=ON -DENABLE_PYTHON=ON -DENABLE_VOLK=ON -DENABLE_GRC=ON "
+  config_opt: " -DENABLE_DOXYGEN=$builddocs -DENABLE_GR_AUDIO=ON -DENABLE_GR_BLOCKS=ON -DENABLE_GR_CHANNELS=ON -DENABLE_GR_DIGITAL=ON -DENABLE_GR_FEC=ON -DENABLE_GR_FFT=ON -DENABLE_GR_FILTER=ON -DENABLE_GR_QTGUI=ON -DENABLE_GR_UHD=ON -DENABLE_GR_SOAPY=ON -DENABLE_PYTHON=ON -DENABLE_GRC=ON "
 inherit: cmake
 configure_static: cmake .. -DCMAKE_BUILD_TYPE=$cmakebuildtype -DCMAKE_INSTALL_PREFIX=$prefix -DENABLE_STATIC_LIBS=True $config_opt
 install: |

--- a/gnuradio39.lwr
+++ b/gnuradio39.lwr
@@ -17,18 +17,41 @@
 # Boston, MA 02110-1301, USA.
 #
 
-inherit: prefix
 depends:
-        - gnuradio
-config:
-  packages:
-    apache-thrift:
-      optional: True
-    wxpython:
-      optional: True
-    doxygen:
-      optional: True
-    gnuradio:
-      gitbranch: maint-3.9
-    gqrx:
-      forcebuild: True
+- boost
+- fftw
+- gsl
+- gmp
+- soapysdr
+- uhd
+- alsa
+- qt5
+- qwt6
+- numpy
+- lxml
+- pycairo
+- pyqt5
+- libvolk
+- liblog4cpp
+- zeromq
+- python-zmq
+- python-click-plugins
+- python-pyqtgraph
+- pyyaml
+- pygobject
+- gobject-introspection
+- gtk3
+- mako
+- pybind11
+- doxygen
+description: Free and open source toolkit for software defined radio
+category: common
+source: git+https://github.com/gnuradio/gnuradio.git
+gitbranch: maint-3.9
+vars: # We explicitly enable some subcomponents to make sure the build fails if they're not working:
+  config_opt: " -DENABLE_DOXYGEN=$builddocs -DENABLE_GR_AUDIO=ON -DENABLE_GR_BLOCKS=ON -DENABLE_GR_CHANNELS=ON -DENABLE_GR_DIGITAL=ON -DENABLE_GR_FEC=ON -DENABLE_GR_FFT=ON -DENABLE_GR_FILTER=ON -DENABLE_GR_QTGUI=ON -DENABLE_GR_UHD=ON -DENABLE_GR_SOAPY=ON -DENABLE_PYTHON=ON -DENABLE_GRC=ON "
+inherit: cmake
+configure_static: cmake .. -DCMAKE_BUILD_TYPE=$cmakebuildtype -DCMAKE_INSTALL_PREFIX=$prefix -DENABLE_STATIC_LIBS=True $config_opt
+install: |
+    make install
+    make install


### PR DESCRIPTION
Reorganize the gnuradio recipes so that:
- gnuradio39 and gnuradio-master are full recipes for GNU Radio
- gnuradio is a copy of gnuradio39
- gnuradio-default and gnuradio-stable init recipes
  - depend on gnuradio39
  - use uhd gitbranch: UHD-4.0