### PR TITLE
qt5: debian distros based on bullseye no longer require qt5-default

### DIFF
--- a/qt5.lwr
+++ b/qt5.lwr
@@ -19,7 +19,7 @@
 
 category: baseline
 satisfy:
-  deb: libqt5opengl5-dev && libqt5svg5-dev && qt5-default
+  deb: qtbase5-dev && libqt5opengl5-dev && libqt5svg5-dev
   rpm: (qt5-qtbase-devel && qt5-qtsvg-devel) || (devel_qt5 && libqt5-qtsvg-devel)
   pacman: qt5-base
   port: qt5 && qt5-qtbase


### PR DESCRIPTION
Debian stable as of bullseye no longer has a qt5-default package, as
qt4 support was removed and qt5 is default.  Distros based on debian
will not have this package.

Relates to https://github.com/gnuradio/pybombs/issues/555

On Debian 11 (bullseye), I ran the installation with the updated qt5 recipe and everything installed fine, and I was able to run gnuradio-companion.  I'm not sure if there are other tests to run to confirm, apologies, quite new to gnuradio.  

Note answer here for Ubuntu:
https://bugs.launchpad.net/ubuntu/+source/qtbase-opensource-src/+bug/1926802

Honestly, I'm not clear if this fix is really correct, because i think the recipe needs to be sync'd to the Debian 11 epoch.  Pre Debian 11, the old recipe works, where-as post Debian 11, the old recipe wont.  