### PR TITLE
gnuradio39.lwr: gnuradio 3.9 requires pybind11

### DIFF
--- a/gnuradio39.lwr
+++ b/gnuradio39.lwr
@@ -19,6 +19,7 @@
 
 inherit: prefix
 depends:
+        - pybind11
         - gnuradio
 config:
   packages:


### PR DESCRIPTION
gnuradio.lwr doesn't install pybind11, but this seems to be required for
gnuradio3.9.  A recipe exists for pybind11 and it works.

Signed-off-by: Matt Arcidy <marcidy@gmail.com>

for #267 