### PR TITLE
Update URL of Gqrx repo

### DIFF
--- a/gqrx.lwr
+++ b/gqrx.lwr
@@ -32,4 +32,4 @@ satisfy:
   deb: gqrx-sdr
   port: gqrx
   pacman: gqrx
-source: git+https://github.com/csete/gqrx.git
+source: git+https://github.com/gqrx-sdr/gqrx.git


### PR DESCRIPTION
The project was recently moved from the author's personal GitHub account to a separate GitHub organization.