### PR TITLE
Pyqtgraph and click plugins .lwr file correction for arch linux

### DIFF
--- a/lxml.lwr
+++ b/lxml.lwr
@@ -34,4 +34,5 @@ satisfy:
 satisfy@python3:
   deb: python3-lxml >= 2.3.2
   rpm: python3-lxml >= 2.3.2
+  pacman: python-lxml
 source: wget+http://lxml.de/files/lxml-2.3.3.tgz

--- a/mako.lwr
+++ b/mako.lwr
@@ -32,3 +32,4 @@ satisfy:
 satisfy@python3:
   deb: python3-mako >= 0.4.2
   rpm: python3-mako >= 0.4.2
+  pacman: python-mako

--- a/pygobject.lwr
+++ b/pygobject.lwr
@@ -34,6 +34,7 @@ satisfy:
 satisfy@python3:
   deb: python3-gi && python3-gi-cairo
   rpm: python3-gobject
+  pacman: python-gobject
 source: wget+http://ftp.gnome.org/pub/GNOME/sources/pygobject/2.28/pygobject-2.28.6.tar.bz2
 vars:
   config_opt: ' --disable-introspection '

--- a/python-click-plugins.lwr
+++ b/python-click-plugins.lwr
@@ -24,7 +24,9 @@ description: A module for writing portable GUI applications with Python using Tk
 satisfy:
   deb: python-click-plugins
   rpm: python-click-plugins || python2-click-plugins
+  pacman: python-click-plugins
   port: py27-click-plugins
 satisfy@python3:
   deb: python3-click-plugins
   rpm: python3-click-plugins
+  pacman: python-click-plugins

--- a/python-click-plugins.lwr
+++ b/python-click-plugins.lwr
@@ -24,7 +24,6 @@ description: A module for writing portable GUI applications with Python using Tk
 satisfy:
   deb: python-click-plugins
   rpm: python-click-plugins || python2-click-plugins
-  pacman: python-click-plugins
   port: py27-click-plugins
 satisfy@python3:
   deb: python3-click-plugins

--- a/python-pyqtgraph.lwr
+++ b/python-pyqtgraph.lwr
@@ -25,7 +25,6 @@ description: Scientific Graphics and GUI Library for Python
 satisfy:
   deb: python-pyqtgraph
   rpm: python-pyqtgraph || python2-pyqtgraph
-  pacman: python-pyqtgraph
   port: py27-pyqtgraph
   python: pyqtgraph
 satisfy@python3:

--- a/python-pyqtgraph.lwr
+++ b/python-pyqtgraph.lwr
@@ -25,8 +25,10 @@ description: Scientific Graphics and GUI Library for Python
 satisfy:
   deb: python-pyqtgraph
   rpm: python-pyqtgraph || python2-pyqtgraph
+  pacman: python-pyqtgraph
   port: py27-pyqtgraph
   python: pyqtgraph
 satisfy@python3:
   deb: python3-pyqtgraph
   rpm: python3-pyqtgraph
+  pacman: python-pyqtgraph

--- a/python-zmq.lwr
+++ b/python-zmq.lwr
@@ -29,3 +29,4 @@ satisfy:
 satisfy@python3:
   deb: python3-zmq
   rpm: python3-zmq
+  pacman: python-pyzmq


### PR DESCRIPTION
Hi, 

I was trying to install Gnuradio 3.8 on my Arch Linux setup and I encountered these 2 issues I gave below.

```
[INFO] Prefix Python version is: 3.9.7
[INFO] Prefix Python version is: 3.9.7
[INFO] Installing default packages for prefix...
[INFO] 
  - gnuradio
[INFO] Phase 1: Creating install tree and installing binary packages:
[ERROR] Package has no install method: python-click-plugins

and 

[INFO] Prefix Python version is: 3.9.7
[INFO] Prefix Python version is: 3.9.7
[INFO] Installing default packages for prefix...
[INFO] 
  - gnuradio
[INFO] Phase 1: Creating install tree and installing binary packages:
[ERROR] Package has no install method: python-pyqtgraph
```
I have fixed the issue by changing responsible .lwr files for those packages. 

