### PR TITLE
gnuradio-main: default GNU Radio branch is now "main"

### DIFF
--- a/gnuradio-main.lwr
+++ b/gnuradio-main.lwr
@@ -1,0 +1,34 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+inherit: prefix
+depends:
+        - gnuradio
+config:
+  packages:
+    apache-thrift:
+      optional: True
+    wxpython:
+      optional: True
+    doxygen:
+      optional: True
+    gnuradio:
+      gitbranch: main
+    gqrx:
+      forcebuild: True


### PR DESCRIPTION
Remove gnuradio-master as a separate step.

Signed-off-by: Jeff Long <willcode4@gmail.com>