### PR TITLE
Update osmocom.org git URLs

### DIFF
--- a/gr-fosphor.lwr
+++ b/gr-fosphor.lwr
@@ -28,5 +28,5 @@ gitbranch: master
 inherit: cmake
 satisfy:
   port: gr-fosphor
-source: git+https://git.osmocom.org/gr-fosphor
+source: git+https://gitea.osmocom.org/sdr/gr-fosphor.git
 mirror: git+https://github.com/osmocom/gr-fosphor

--- a/gr-iqbal.lwr
+++ b/gr-iqbal.lwr
@@ -25,5 +25,5 @@ description: Gnuradio I/Q balancing
 gitbranch: master
 inherit: cmake
 # Let's always build this from source, not binaries
-source: git+https://git.osmocom.org/gr-iqbal
+source: git+https://gitea.osmocom.org/sdr/gr-iqbal.git
 mirror: git+https://github.com/osmocom/gr-iqbal

--- a/gr-op25.lwr
+++ b/gr-op25.lwr
@@ -27,4 +27,4 @@ depends:
 description: Implementation of the APCO Project 25 digital radio standard
 gitbranch: master
 inherit: cmake
-source: git+https://git.osmocom.org/op25
+source: git+https://gitea.osmocom.org/op25/op25.git

--- a/gr-osmosdr.lwr
+++ b/gr-osmosdr.lwr
@@ -34,6 +34,6 @@ description: Interface API independent of the underlying radio hardware
 gitbranch: master
 inherit: cmake
 # Let's always build this from source, not binaries
-source: git+https://git.osmocom.org/gr-osmosdr
+source: git+https://gitea.osmocom.org/sdr/gr-osmosdr.git
 vars:
   config_opt: ' -DENABLE_NONFREE=TRUE '

--- a/libosmo-dsp.lwr
+++ b/libosmo-dsp.lwr
@@ -29,5 +29,5 @@ gitbranch: master
 inherit: autoconf
 satisfy:
   port: libosmo-dsp
-source: git+https://git.osmocom.org/libosmo-dsp
+source: git+https://gitea.osmocom.org/sdr/libosmo-dsp.git
 installdir: .

--- a/libosmocore.lwr
+++ b/libosmocore.lwr
@@ -33,6 +33,6 @@ depends:
 description: A library with generic ulitity functions developed by Osmocom project
 gitbranch: master
 inherit: autoconf
-source: git+https://git.osmocom.org/libosmocore
+source: git+https://gitea.osmocom.org/osmocom/libosmocore.git
 vars:
   config_opt: ' --disable-libsctp '

--- a/osmo-fl2k.lwr
+++ b/osmo-fl2k.lwr
@@ -23,4 +23,4 @@ depends:
 description: Turns FL2000-based USB 3.0 to VGA adapters into low cost DACs
 gitbranch: master
 inherit: cmake
-source: git+https://git.osmocom.org/osmo-fl2k
+source: git+https://gitea.osmocom.org/sdr/osmo-fl2k.git

--- a/osmo-sdr.lwr
+++ b/osmo-sdr.lwr
@@ -29,4 +29,4 @@ makedir: software/libosmosdr/build
 satisfy:
   deb: osmo-sdr && libosmosdr-dev
   pacman: gnuradio-osmosdr
-source: git+https://git.osmocom.org/osmo-sdr
+source: git+https://gitea.osmocom.org/sdr/osmo-sdr.git

--- a/osmo-tetra.lwr
+++ b/osmo-tetra.lwr
@@ -40,7 +40,7 @@ make: 'cd ../src
   make
 
   '
-source: git+https://git.osmocom.org/osmo-tetra
+source: git+https://gitea.osmocom.org/tetra/osmo-tetra.git
 uninstall: 'rm $prefix/lib/libosmo-tetra-mac.a
 
   rm $prefix/lib/libosmo-tetra-phy.a

--- a/rtl-sdr.lwr
+++ b/rtl-sdr.lwr
@@ -29,6 +29,6 @@ satisfy:
   portage: net-wireless/rtl-sdr
   pacman: rtl-sdr
   rpm: rtl-sdr
-source: git+https://git.osmocom.org/rtl-sdr
+source: git+https://gitea.osmocom.org/sdr/rtl-sdr.git
 vars:
   config_opt: ' -DDETACH_KERNEL_DRIVER=ON '


### PR DESCRIPTION
Osmocom recently migrated to Gitea, so their repositories have new URLs. HTTP forwarding is working for now, but we may as well update recipes to use the new addresses.