### PR TITLE
Add gr-funcube recipe

### DIFF
--- a/gr-funcube.lwr
+++ b/gr-funcube.lwr
@@ -1,0 +1,30 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: hardware
+depends:
+- gnuradio
+- libusb
+- libhidapi
+description: GNURadio FUNcube Dongle and FUNcube Dongle Pro+ sources
+gitbranch: main
+inherit: cmake
+satisfy:
+  deb: gr-funcube && qthid-fcd-controller
+source: git+https://github.com/dl1ksv/gr-funcube.git


### PR DESCRIPTION
This adds gr-funcube (https://github.com/dl1ksv/gr-funcube), which replaces gr-fcdproplus in GNU Radio 3.9 and later.

FYI @dl1ksv

Signed-off-by: Clayton Smith <argilo@gmail.com>