### PR TITLE
gnuradio: Add soapysdr as a dependency

### DIFF
--- a/gnuradio.lwr
+++ b/gnuradio.lwr
@@ -46,6 +46,7 @@ depends:
 - pybind11
 - spdlog
 - libsndfile
+- soapysdr
 description: Free and open source toolkit for software defined radio
 category: common
 satisfy:


### PR DESCRIPTION
The gr-soapy module was added to GNU Radio in version 3.9.2. Making it a dependency will ensure that gr-soapy gets built when GNU Radio is installed.