### PR TITLE
Add libiio dependency to gnuradio recipe

### DIFF
--- a/gnuradio.lwr
+++ b/gnuradio.lwr
@@ -47,6 +47,7 @@ depends:
 - spdlog
 - libsndfile
 - soapysdr
+- libiio
 description: Free and open source toolkit for software defined radio
 category: common
 satisfy:


### PR DESCRIPTION
GNU Radio 3.10 added gr-iio, but this module doesn't build unless libiio is present. Adding it as a dependency will ensure that it's always installed prior to building GNU Radio.