### PR TITLE
Support for renamed branch "main" in the repository "analogdevicesinc/libiio"

### DIFF
--- a/libiio.lwr
+++ b/libiio.lwr
@@ -22,6 +22,7 @@ depends:
 - libxml
 - libusb
 description: Library for interfacing with IIO devices
+gitbranch: main
 gitrev: tags/v0.21
 inherit: cmake
 satisfy:


### PR DESCRIPTION
This change was made for the processing "gnuradio-default" recipe of the gnuradio/pybombs repository.

Since the default branch in the "analogdevicesinc/libiio" repository became "main" instead of "master" we got error while building:

> Cloning into 'libiio'...
> fatal: Remote branch master not found in upstream origin