### PR TITLE
gr-bladeRF: add gr-osmosdr dependency

### DIFF
--- a/gr-bladeRF.lwr
+++ b/gr-bladeRF.lwr
@@ -21,6 +21,7 @@ category: common
 depends:
 - gnuradio
 - bladeRF
+- gr-osmosdr
 description: bladeRF hardware specific GNURadio sink and source blocks
 gitbranch: main
 inherit: cmake


### PR DESCRIPTION
Fixes the gr-osmosdr prerequisite for gr-bladeRF.