### PR TITLE
Change http to https in gnss-sdr recipe

### DIFF
--- a/gnss-sdr.lwr
+++ b/gnss-sdr.lwr
@@ -33,4 +33,4 @@ inherit: cmake
 makedir: build
 satisfy:
   port: gnss-sdr
-source: git+http://github.com/gnss-sdr/gnss-sdr.git
+source: git+https://github.com/gnss-sdr/gnss-sdr.git


### PR DESCRIPTION
The old `http` seems to be causing problems in some environments. 