### PR TITLE
uhd: Update to version 4.6

### DIFF
--- a/uhd.lwr
+++ b/uhd.lwr
@@ -33,7 +33,7 @@ satisfy:
   port: uhd
   portage: net-wireless/uhd
 source: git+https://github.com/EttusResearch/uhd.git
-gitbranch: UHD-4.2
+gitbranch: UHD-4.6
 inherit: cmake
 configuredir: host/build
 makedir: host/build


### PR DESCRIPTION
I've updated to the latest 4.6 release, because 4.2 fails to build on Ubuntu 24.04.