### PR TITLE
Update gr-foo and gr-ieee-80211 to GNU Radio 3.10

### DIFF
--- a/gr-foo.lwr
+++ b/gr-foo.lwr
@@ -21,7 +21,7 @@ category: common
 depends:
 - gnuradio
 description: Some additional blocks like packetpad that are required by, e.g., gr-ieee80211
-gitbranch: maint-3.8
+gitbranch: maint-3.10
 inherit: cmake
 satisfy:
   port: gr-foo

--- a/gr-ieee-80211.lwr
+++ b/gr-ieee-80211.lwr
@@ -24,7 +24,7 @@ depends:
 - liblog4cpp
 - gr-foo
 description: IEEE 802.11 a/g/p Transceiver
-gitbranch: maint-3.8
+gitbranch: maint-3.10
 inherit: cmake
 satisfy:
   port: gr-ieee802-11


### PR DESCRIPTION
GNU Radio 3.10 was released nearly three years ago, so I think it makes sense to update the PyBOMBS recipes that still point at earlier versions.